### PR TITLE
Add VariableAssignment to the XML backend

### DIFF
--- a/Backend2.ST/xml.stg
+++ b/Backend2.ST/xml.stg
@@ -32,6 +32,9 @@ ModuleXml(sName, arrsImportedModules, arrsExpTypes, arrsExpVars, arrsTases, arrs
 <TypeAssignments>
     $arrsTases;separator="\n"$
 </TypeAssignments>
+<VariablesAssignments>
+    $arrsVases;separator="\n"$
+</VariablesAssignments>
 </Asn1Module >
 >>
 


### PR DESCRIPTION
The XML backend had an unused parameter, containing the ASN.1 constants. I added it in the template, can you check if that's OK?