### PR TITLE
Fixing icd generator

### DIFF
--- a/Antlr/Comments.cs
+++ b/Antlr/Comments.cs
@@ -21,18 +21,26 @@ namespace Antlr
             {
                 IToken t = FileTokens[nextTokenIndex++];
                 if (alreadyTakenComments.Contains(t))
+                {
                     break;
+                }
                 if (t.Line != lastTokenLineNo)
+                {
                     break;
+                }
                 if (t.Type == asn1Lexer.WS)
+                {
                     continue;
+                }
                 else if (t.Type == asn1Lexer.COMMENT || t.Type == asn1Lexer.COMMENT2)
                 {
                         comments.Insert(0, t.Text);
                         alreadyTakenComments.Add(t);
                 }
                 else
+                {
                     break;
+                }
 
             }
 

--- a/Ast/CreateAsn1AstFromAntlrTree.fs
+++ b/Ast/CreateAsn1AstFromAntlrTree.fs
@@ -117,7 +117,7 @@ and CreateChoiceChild (astRoot:list<ITree>) (tree:ITree) (fileTokens:array<IToke
                 Type = CreateType astRoot sec fileTokens alreadyTakenComments ; 
                 Optionality=None; 
                 AcnInsertedField=false
-                Comments = Antlr.Comment.GetComments(fileTokens, alreadyTakenComments, fileTokens.[tree.TokenStopIndex].Line, tree.TokenStartIndex - 1, tree.TokenStopIndex + 2)
+                Comments = Antlr.Comment.GetComments(fileTokens, alreadyTakenComments, fileTokens.[x.TokenStopIndex].Line, x.TokenStartIndex - 1, x.TokenStopIndex + 2)
             }
         | _ -> raise (BugErrorException("Bug in CreateChoiceChild"))
     )

--- a/Ast/CreateAsn1AstFromAntlrTree.fs
+++ b/Ast/CreateAsn1AstFromAntlrTree.fs
@@ -204,7 +204,7 @@ and CreateSequenceChild (astRoot:list<ITree>) (tree:ITree) (fileTokens:array<ITo
                                     | (None, None)      -> None
                                     | _                 -> raise (BugErrorException("Bug in CreateSequenceChild")) 
                     AcnInsertedField=false
-                    Comments = Antlr.Comment.GetComments(fileTokens, alreadyTakenComments, fileTokens.[tree.TokenStopIndex].Line, tree.TokenStartIndex - 1, tree.TokenStopIndex + 2)
+                    Comments = Antlr.Comment.GetComments(fileTokens, alreadyTakenComments, fileTokens.[x.TokenStopIndex].Line, x.TokenStartIndex - 1, x.TokenStopIndex + 2)
                 }
             ChildInfo chInfo
         | asn1Parser.COMPONENTS_OF -> 

--- a/Backend2/icdAcn.fs
+++ b/Backend2/icdAcn.fs
@@ -209,7 +209,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
             | PosInf(_)   | Full                   -> raise(BugErrorException "")
             | Empty                                -> 0I
             | NegInf(_)                            -> raise(BugErrorException "")
-        let sFixedLengthComment = sprintf "Length is Fixed equal to  %A, so no length determinant is encoded." nMax
+        let sFixedLengthComment = sprintf "Length is Fixed equal to %A, so no length determinant is encoded." nMax
         let arRows, sExtraComment =
             match Acn.GetSizeableEncodingClass t path r acn emptyLocation,  nMax>=2I with
             | Acn.FixedSize(nSize), true      -> (ChildRow 1I)::(icd_uper.EmitRowWith3Dots())::(ChildRow nMax)::[], sFixedLengthComment

--- a/Backend2/icdUper.fs
+++ b/Backend2/icdUper.fs
@@ -217,7 +217,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
             | Concrete(a,b)  when a=b && b<2I     -> [ChildRow 1I]
             | Concrete(a,b)  when a=b && b>=2I      -> (ChildRow 1I)::(icd_uper.EmitRowWith3Dots())::(ChildRow b)::[]
             | Concrete(a,b)  when a<>b && b<2I    -> LengthRow::(ChildRow 2I)::[]
-            | Concrete(a,b)                        -> LengthRow::(ChildRow 2I)::(icd_uper.EmitRowWith3Dots())::(ChildRow b)::[]
+            | Concrete(a,b)                        -> LengthRow::(ChildRow 2I)::(icd_uper.EmitRowWith3Dots())::(ChildRow (b+1I))::[]
             | PosInf(_)                            
             | Full                                 -> LengthRow::(ChildRow 2I)::(icd_uper.EmitRowWith3Dots())::(ChildRow 65535I)::[]
             | NegInf(_)                            -> raise(BugErrorException "")

--- a/Backend2/icdUper.fs
+++ b/Backend2/icdUper.fs
@@ -168,10 +168,10 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
             let charSet = GetTypeUperRangeFrom(t.Kind, t.Constraints, r)
             let charSize = GetNumberOfBitsForNonNegativeInteger (BigInteger (charSet.Length-1))
             charSize.ToString()
-        let ChildRow (i:int) =
-            let sClass = if i % 2 = 0 then icd_uper.EvenRow() else icd_uper.OddRow()
+        let ChildRow (i:BigInteger) =
+            let sClass = if i % 2I = 0I then icd_uper.EvenRow() else icd_uper.OddRow()
             let nIndex = BigInteger i
-            let sFieldName = sprintf "Item #%d" i
+            let sFieldName = sprintf "Item #%A" i
             let sComment = ""
             let sType, sAsn1Constraints, sMinBits, sMaxBits = 
                 match t.Kind with
@@ -214,9 +214,9 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
         
         let arRows = 
             match (GetTypeUperRange t.Kind t.Constraints  r) with
-            | Concrete(a,b)  when a=b && b<=2I     -> [ChildRow 1]
-            | Concrete(a,b)  when a=b && b>2I      -> (ChildRow 1)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int b))::[]
-            | Concrete(a,b)  when a<>b && b<=2I    -> LengthRow::(ChildRow 2)::[]
+            | Concrete(a,b)  when a=b && b<2I     -> [ChildRow 1]
+            | Concrete(a,b)  when a=b && b>=2I      -> (ChildRow 1)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int b))::[]
+            | Concrete(a,b)  when a<>b && b<2I    -> LengthRow::(ChildRow 2)::[]
             | Concrete(a,b)                        -> LengthRow::(ChildRow 2)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int b))::[]
             | PosInf(_)                            
             | Full                                 -> LengthRow::(ChildRow 2)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int 65535))::[]

--- a/Backend2/icdUper.fs
+++ b/Backend2/icdUper.fs
@@ -216,7 +216,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
 
         let arRows, sExtraComment = 
             match (GetTypeUperRange t.Kind t.Constraints  r) with
-            | Concrete(a,b)  when a=b && b<2I     -> [ChildRow 1I], "The arrary contains a single element."
+            | Concrete(a,b)  when a=b && b<2I     -> [ChildRow 1I], "The array contains a single element."
             | Concrete(a,b)  when a=b && b=2I    -> (ChildRow 1I)::(ChildRow 2I)::[], (sFixedLengthComment b)
             | Concrete(a,b)  when a=b && b>2I    -> (ChildRow 1I)::(icd_uper.EmitRowWith3Dots())::(ChildRow b)::[], (sFixedLengthComment b)
             | Concrete(a,b)  when a<>b && b<2I    -> LengthRow::(ChildRow 2I)::[],""

--- a/Backend2/icdUper.fs
+++ b/Backend2/icdUper.fs
@@ -170,7 +170,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
             charSize.ToString()
         let ChildRow (i:BigInteger) =
             let sClass = if i % 2I = 0I then icd_uper.EvenRow() else icd_uper.OddRow()
-            let nIndex = BigInteger i
+            let nIndex = i
             let sFieldName = sprintf "Item #%A" i
             let sComment = ""
             let sType, sAsn1Constraints, sMinBits, sMaxBits = 
@@ -214,12 +214,12 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
         
         let arRows = 
             match (GetTypeUperRange t.Kind t.Constraints  r) with
-            | Concrete(a,b)  when a=b && b<2I     -> [ChildRow 1]
-            | Concrete(a,b)  when a=b && b>=2I      -> (ChildRow 1)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int b))::[]
-            | Concrete(a,b)  when a<>b && b<2I    -> LengthRow::(ChildRow 2)::[]
-            | Concrete(a,b)                        -> LengthRow::(ChildRow 2)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int b))::[]
+            | Concrete(a,b)  when a=b && b<2I     -> [ChildRow 1I]
+            | Concrete(a,b)  when a=b && b>=2I      -> (ChildRow 1I)::(icd_uper.EmitRowWith3Dots())::(ChildRow b)::[]
+            | Concrete(a,b)  when a<>b && b<2I    -> LengthRow::(ChildRow 2I)::[]
+            | Concrete(a,b)                        -> LengthRow::(ChildRow 2I)::(icd_uper.EmitRowWith3Dots())::(ChildRow b)::[]
             | PosInf(_)                            
-            | Full                                 -> LengthRow::(ChildRow 2)::(icd_uper.EmitRowWith3Dots())::(ChildRow (int 65535))::[]
+            | Full                                 -> LengthRow::(ChildRow 2I)::(icd_uper.EmitRowWith3Dots())::(ChildRow 65535I)::[]
             | NegInf(_)                            -> raise(BugErrorException "")
             | Empty                                -> []
 


### PR DESCRIPTION
Fixed various issues related to ICD generation:

- inline comments used in SEQUENCE and CHOICE fields were not properly parsed and therefore did not appear in the right column of the ICDs

- UPER ICDs has few issues with the handling of SIZE constraint in SEQUENCE OF