### PR TITLE
Fixing icd generator

### DIFF
--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -411,7 +411,7 @@ namespace Asn1f2
             var procName = "asn1";
             Console.Error.WriteLine();
             Console.Error.WriteLine("Semantix ASN.1 Compiler");
-            Console.Error.WriteLine("Current Version is: 3.0.{0} ", Svn.Version);
+            Console.Error.WriteLine("Current Version is: 3.1.{0} ", Svn.Version);
             Console.Error.WriteLine("Usage:");
             Console.Error.WriteLine();
             Console.Error.WriteLine("{0}  <OPTIONS> file1, file2, ..., fileN ", procName);
@@ -465,6 +465,9 @@ namespace Asn1f2
             Console.Error.WriteLine();
             Console.Error.WriteLine("\t -atc\t\t\tcreate automatic test cases.");
             Console.Error.WriteLine("\t\t\t\tDefault is current directory");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("\t -equal \t\tGenerate functions for testing type equality");
+            Console.Error.WriteLine("\t\t\t\tWhen using Ada, compiler must support Ada2012");
             Console.Error.WriteLine();
             Console.Error.WriteLine();
             Console.Error.WriteLine("Example:");

--- a/Asn1f2/SvnVersion.cs
+++ b/Asn1f2/SvnVersion.cs
@@ -1,1 +1,1 @@
-namespace Asn1f2 { public class Svn    { public const string Version = "987";    }} 
+namespace Asn1f2 { public class Svn    { public const string Version = "0";    }} 

--- a/Asn1f2/SvnVersion.cs
+++ b/Asn1f2/SvnVersion.cs
@@ -1,1 +1,1 @@
-namespace Asn1f2 { public class Svn    { public const string Version = "986";    }} 
+namespace Asn1f2 { public class Svn    { public const string Version = "987";    }} 

--- a/Backend2.ST/icd_acn.stg
+++ b/Backend2.ST/icd_acn.stg
@@ -4,8 +4,9 @@ group icd_acn;
 
 
 
+ItemNumber(nIndex) ::= "Item #$nIndex$"
 
-EmitSequenceOrChoice(sColor, sTasName, sTasNameC, bHasAcnDef, sAsn1Kinf, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren, arrsParams) ::= <<
+EmitSequenceOrChoice(sColor, sTasName, sTasNameC, bHasAcnDef, sAsn1Kinf, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren, arrsParams, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>
@@ -85,7 +86,7 @@ Special field used by ACN to indicate which choice alternative is present.
 
 
 
-EmitPrimitiveType(sColor, sTasName, sTasNameC, bHasAcnDef, sAsnKindName, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, sAsn1Constraints, sMinBits, sMaxBits, arrsParams) ::= <<
+EmitPrimitiveType(sColor, sTasName, sTasNameC, bHasAcnDef, sAsnKindName, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, sAsn1Constraints, sMinBits, sMaxBits, arrsParams, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>
@@ -139,7 +140,7 @@ $endif$
 
 
 /* *********** SEQUENCE OF, OCTET STRING etc ********** */
-EmitSizeable(sColor, sTasName, sTasNameC, bHasAcnDef, sKind, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsRows, arrsParams) ::= <<
+EmitSizeable(sColor, sTasName, sTasNameC, bHasAcnDef, sKind, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsRows, arrsParams, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>

--- a/Backend2.ST/icd_uper.stg
+++ b/Backend2.ST/icd_uper.stg
@@ -9,6 +9,8 @@ NewLine() ::= "<br/>"
 Orange() ::= "#FF8f00"
 Blue() ::= "#379CEE"
 
+ItemNumber(nIndex) ::= "Item #$nIndex$"
+
 RealSizeExplained() ::= <<
 <a href="#REAL_SIZE_EXPLAINED123"><span style="vertical-align: super">why?</span></a>
 >>

--- a/Backend2.ST/icd_uper.stg
+++ b/Backend2.ST/icd_uper.stg
@@ -44,7 +44,7 @@ $arrsItems;separator="\n"$
 >>
 
 // applicable to Integers, booleans, reals
-EmitPrimitiveType(sColor, sTasName, sTasNameC, sAsnKindName, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, sAsn1Constraints, sMinBits, sMaxBits) ::= <<
+EmitPrimitiveType(sColor, sTasName, sTasNameC, sAsnKindName, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, sAsn1Constraints, sMinBits, sMaxBits, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>
@@ -89,7 +89,7 @@ $endif$
 
 
 
-EmitSequence(sColor, sTasName, sTasNameC, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren) ::= <<
+EmitSequence(sColor, sTasName, sTasNameC, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>
@@ -173,7 +173,7 @@ $arrsOptChildren;separator="\n"$
 
 
 /* *** CHOICE ****/
-EmitChoice(sColor, sTasName, sTasNameC, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren) ::= <<
+EmitChoice(sColor, sTasName, sTasNameC, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>
@@ -243,7 +243,7 @@ $arrsOptChildren;separator="\n"$
 
 /* *********** CHOICE END ********** */
 /* *********** SEQUENCE OF, OCTET STRING etc ********** */
-EmitSizeable(sColor, sTasName, sTasNameC, sKind, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsRows) ::= <<
+EmitSizeable(sColor, sTasName, sTasNameC, sKind, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsRows, arrsComments) ::= <<
 <a name="ICD_$sTasNameC$"></a> 
 <table border="0" width="100%" >
 <tbody>

--- a/Backend2/icdAcn.fs
+++ b/Backend2/icdAcn.fs
@@ -8,14 +8,14 @@ open VisitTree
 open CloneTree
 open spark_utils
 
-    
+
 
 let printPoint (p:AcnTypes.Point) =
     match p with
     | AcnTypes.TypePoint(pth)
     | AcnTypes.TempPoint(pth)        -> pth |> Seq.StrJoin "."
     | AcnTypes.ParamPoint(pth)       -> pth.Tail.Tail |> Seq.StrJoin "."
-    
+
 let makeEmptyNull (s:string) =
     match s with
     | null  -> null
@@ -28,12 +28,12 @@ let printParamType = function
     | AcnTypes.RefTypeCon(_,ts)  -> ts.Value
 
 
-               
+
 
 let getAcnMax (t:Ast.Asn1Type) path (r:AstRoot) (acn:AcnTypes.AcnAstResolved) =
     let (bits, bytes) = Acn.RequiredBitsForAcnEncodingInt t path r acn
     bits.ToString(), bytes.ToString()
-    
+
 let getAcnMin (t:Ast.Asn1Type) path (r:AstRoot) (acn:AcnTypes.AcnAstResolved) =
     let (bits, bytes) = Acn.RequiredMinBitsForAcnEncodingInt t path r acn
     bits.ToString(), bytes.ToString()
@@ -67,7 +67,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
 
     let sCommentLine = GetCommentLine tas.Comments t
 
-    
+
 
     let EmitSeqOrChoiceChild (i:int) (ch:ChildInfo) (optionalLikeUperChildren:ChildInfo list) getPresence =
         let sClass = if i % 2 = 0 then icd_uper.EvenRow() else icd_uper.OddRow()
@@ -177,7 +177,8 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
             | Some(Acn.EnumDeterminant(extFld))  -> Choice_enm extFld
             | Some(Acn.PresentWhenOnChildren)   -> Choice_presWhen()
             | None                              -> Choice_like_uPER()
-        icd_acn.EmitSequenceOrChoice color sTasName (ToC sTasName) hasAcnDef "CHOICE" sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arrRows (myParams 6I)
+        icd_acn.EmitSequenceOrChoice color sTasName (ToC sTasName) hasAcnDef "CHOICE" sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arrRows (myParams 6I) (sCommentLine.Split [|'\n'|])
+
     | OctetString   
     | NumericString   
     | IA5String   
@@ -204,7 +205,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
                 | BitString                    -> "BIT", "", "1","1"
                 | _                            -> raise(BugErrorException "")
             icd_uper.EmmitChoiceChild sClass nIndex sFieldName sComment  sType sAsn1Constraints sMinBits sMaxBits
-        
+
         let nMax =
             match (uPER.GetTypeUperRange t.Kind t.Constraints  r) with
             | Concrete(_,b)                        -> b
@@ -232,13 +233,13 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
                 | false, false->(ChildRow 1I)::[], sFixedLengthComment
             | Acn.ExternalField(fld), true    -> (ChildRow 1I)::(icd_uper.EmitRowWith3Dots())::(ChildRow nMax)::[], sprintf "Length determined by external field %s" (printPoint fld)
             | Acn.ExternalField(fld), false   -> (ChildRow 1I)::[], sprintf "Length is determined by the external field: %s" (printPoint fld)
-                
+
             | Acn.NullTerminated,_        -> [],""
 
         let sCommentLine = match sCommentLine with
                            | null | ""  -> sExtraComment
                            | _          -> sprintf "%s%s%s" sCommentLine (icd_uper.NewLine()) sExtraComment
-        
+
         icd_acn.EmitSizeable color sTasName  (ToC sTasName) hasAcnDef (icdUper.Kind2Name t) sMinBytes sMaxBytes sMaxBitsExplained (makeEmptyNull sCommentLine) arRows (myParams 5I) (sCommentLine.Split [|'\n'|])
 
 
@@ -262,8 +263,8 @@ let PrintFile1 (f:Asn1File)  (r:AstRoot) (acn:AcnTypes.AcnAstResolved)  =
     let modules = f.Modules |> Seq.map (fun  m -> PrintModule m f r acn )  
     icd_uper.EmmitFile (Path.GetFileName f.FileName) modules 
 
-let PrintFile3 (r:AstRoot) (acn:AcnTypes.AcnAstResolved) = 
-    
+let PrintFile3 (r:AstRoot) (acn:AcnTypes.AcnAstResolved) =
+
     acn.Files |>
     Seq.map(fun (fName, tokens) -> 
             let f = r.Files |> Seq.find(fun x -> Path.GetFileNameWithoutExtension(x.FileName) = Path.GetFileNameWithoutExtension(fName))
@@ -271,8 +272,6 @@ let PrintFile3 (r:AstRoot) (acn:AcnTypes.AcnAstResolved) =
             let content = Antlr.Html.getAcnInHtml(tokens, tasNames)
             icd_uper.EmmitFilePart2  (Path.GetFileName fName) content
     )
-
-    
 
 
 let DoWork (r:AstRoot) (acn:AcnTypes.AcnAstResolved) outDir =

--- a/Backend2/icdAcn.fs
+++ b/Backend2/icdAcn.fs
@@ -63,7 +63,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
                 | _     -> singleComment + (icd_uper.NewLine ()) + extraComment
             | _                 -> singleComment
         let ret = ret.Replace("/*","").Replace("*/","").Replace("--","")
-        if ret.Trim() = "" then null else ret  
+        if ret.Trim() = "" then null else ret.Trim()
 
     let sCommentLine = GetCommentLine tas.Comments t
 
@@ -105,7 +105,8 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
     | Boolean   
     | NullType
     | Enumerated(_) ->
-        icd_acn.EmitPrimitiveType color sTasName (ToC sTasName) hasAcnDef sKind sMinBytes sMaxBytes sMaxBitsExplained sCommentLine ( if sAsn1Constraints.Trim() ="" then "N.A." else sAsn1Constraints) sMinBits sMaxBits (myParams 2I)
+        icd_acn.EmitPrimitiveType color sTasName (ToC sTasName) hasAcnDef sKind sMinBytes sMaxBytes sMaxBitsExplained sCommentLine ( if sAsn1Constraints.Trim() ="" then "N.A." else sAsn1Constraints) sMinBits sMaxBits (myParams 2I) (sCommentLine.Split [|'\n'|])
+
     |ReferenceType(modl,tsName,_) ->
         let baseTypeWithCons = Ast.GetActualTypeAllConsIncluded t r
         printType tas baseTypeWithCons [modl.Value; tsName.Value] m r acn color
@@ -140,7 +141,8 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
             | None          -> arChildren 1
             | Some(prm)     -> prm::(arChildren 2)
 
-        icd_acn.EmitSequenceOrChoice color sTasName (ToC sTasName) hasAcnDef "SEQUENCE" sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows (myParams 6I)
+        icd_acn.EmitSequenceOrChoice color sTasName (ToC sTasName) hasAcnDef "SEQUENCE" sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows (myParams 6I) (sCommentLine.Split [|'\n'|])
+
 
     |Choice(children)   -> 
         let Choice_like_uPER() =
@@ -184,7 +186,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
         let ChildRow (i:BigInteger) =
             let sClass = if i % 2I = 0I then icd_uper.EvenRow() else icd_uper.OddRow()
             let nIndex = i
-            let sFieldName = sprintf "Item #%A" i
+            let sFieldName = icd_acn.ItemNumber(i)
             let sComment = ""
             let sType, sAsn1Constraints, sMinBits, sMaxBits = 
                 match t.Kind with
@@ -237,7 +239,8 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) path (m:Asn1Module) 
                            | null | ""  -> sExtraComment
                            | _          -> sprintf "%s%s%s" sCommentLine (icd_uper.NewLine()) sExtraComment
         
-        icd_acn.EmitSizeable color sTasName  (ToC sTasName) hasAcnDef (icdUper.Kind2Name t) sMinBytes sMaxBytes sMaxBitsExplained (makeEmptyNull sCommentLine) arRows (myParams 5I)
+        icd_acn.EmitSizeable color sTasName  (ToC sTasName) hasAcnDef (icdUper.Kind2Name t) sMinBytes sMaxBytes sMaxBitsExplained (makeEmptyNull sCommentLine) arRows (myParams 5I) (sCommentLine.Split [|'\n'|])
+
 
 
 

--- a/Backend2/icdUper.fs
+++ b/Backend2/icdUper.fs
@@ -63,7 +63,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
                 | _     -> singleComment + (icd_uper.NewLine ()) + extraComment
             | _                 -> singleComment
         let ret = ret.Replace("/*","").Replace("*/","").Replace("--","")
-        if ret.Trim() = "" then null else ret  
+        if ret.Trim() = "" then null else ret.Trim()
     match t.Kind with
     | Integer    
     | Real    
@@ -78,7 +78,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
         let sCommentLine = GetCommentLine tas.Comments t
         let sAsn1Constraints = t.Constraints |> Seq.map PrintAsn1.PrintConstraint |> Seq.StrJoin ""
 
-        icd_uper.EmitPrimitiveType color sTasName (ToC sTasName) sKind sMinBytes sMaxBytes sMaxBitsExplained sCommentLine ( if sAsn1Constraints.Trim() ="" then "N.A." else sAsn1Constraints) sMinBits sMaxBits
+        icd_uper.EmitPrimitiveType color sTasName (ToC sTasName) sKind sMinBytes sMaxBytes sMaxBitsExplained sCommentLine ( if sAsn1Constraints.Trim() ="" then "N.A." else sAsn1Constraints) sMinBits sMaxBits (sCommentLine.Split [|'\n'|])
         
     |ReferenceType(_) ->
         let baseTypeWithCons = Ast.GetActualTypeAllConsIncluded t r
@@ -125,7 +125,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
             | None          -> arChildren 1
             | Some(prm)     -> prm::(arChildren 2)
 
-        icd_uper.EmitSequence color sTasName (ToC sTasName) sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows
+        icd_uper.EmitSequence color sTasName (ToC sTasName) sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows (sCommentLine.Split [|'\n'|])
 
     |Choice(children)   -> 
         let EmitChild (i:int) (ch:ChildInfo) =
@@ -157,7 +157,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
         let arChildren = children |> Seq.mapi(fun i ch -> EmitChild (2 + i) ch) |> Seq.toList
         let arRows = ChIndex::arChildren
 
-        icd_uper.EmitChoice color sTasName (ToC sTasName) sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows
+        icd_uper.EmitChoice color sTasName (ToC sTasName) sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows (sCommentLine.Split [|'\n'|])
 
     | OctetString   
     | NumericString   
@@ -231,7 +231,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
                            | _          -> sprintf "%s%s%s" (GetCommentLine tas.Comments t) (icd_uper.NewLine()) sExtraComment
 
 
-        icd_uper.EmitSizeable color sTasName  (ToC sTasName) (Kind2Name t) sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows
+        icd_uper.EmitSizeable color sTasName  (ToC sTasName) (Kind2Name t) sMinBytes sMaxBytes sMaxBitsExplained sCommentLine arRows (sCommentLine.Split [|'\n'|])
 
 
 let PrintTas (tas:Ast.TypeAssignment) (r:AstRoot) (acn:AcnTypes.AcnAstResolved) blueTasses =

--- a/Backend2/icdUper.fs
+++ b/Backend2/icdUper.fs
@@ -171,7 +171,7 @@ let rec printType (tas:Ast.TypeAssignment) (t:Ast.Asn1Type) (r:AstRoot) (acn:Acn
         let ChildRow (i:BigInteger) =
             let sClass = if i % 2I = 0I then icd_uper.EvenRow() else icd_uper.OddRow()
             let nIndex = i
-            let sFieldName = sprintf "Item #%A" i
+            let sFieldName = icd_uper.ItemNumber(i)
             let sComment = ""
             let sType, sAsn1Constraints, sMinBits, sMaxBits = 
                 match t.Kind with

--- a/contrib/icd_uper_latex.stg
+++ b/contrib/icd_uper_latex.stg
@@ -1,0 +1,303 @@
+group icd_uper;
+
+//delimiters "$", "$"
+
+Infinity() ::= <<
+\infty
+
+>>
+
+NewLine() ::= <<
+\newline
+
+>>
+
+ItemNumber(nIndex) ::= <<
+Item $nIndex$
+>>
+
+Orange() ::= "#FF8f00"
+Blue() ::= "#379CEE"
+
+RealSizeExplained() ::= <<
+why?~\ref{app:REAL_SIZE_EXPLAINED123}
+>>
+
+IntSizeExplained() ::= <<
+why?~\ref{app:INT_SIZE_EXPLAINED123}
+>>
+
+ArraySizeExplained() ::= <<
+why?~\ref{app:ARRAYS_SIZE_EXPLAINED123}
+>>
+
+ZeroSizeExplained() ::= <<
+why?~\ref{app:ZERO_BITS_EXPLAINED123}
+>>
+
+EmitEnumItem(sName, nValue) ::= <<
+\item $sName$ ($nValue$)
+>>
+
+EmitEnumItemWithComment(sName, nValue, sComment) ::= <<
+\item $sName$ ($nValue$) -- $sComment$
+>>
+
+EmitEnumInternalContents(arrsItems) ::= <<
+Enumeration's values:
+\begin{fw_itemize}
+$arrsItems;separator="\n"$
+\end{fw_itemize}
+>>
+
+// applicable to Integers, booleans, reals, enumerated
+EmitPrimitiveType(sColor, sTasName, sTasNameC, sAsnKindName, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, sAsn1Constraints, sMinBits, sMaxBits, arrsComments) ::= <<
+\subsection{$if(sCommentLine)$$first(arrsComments)$$else$$sTasName$$endif$}\label{sec:ICD_$sTasNameC$}
+
+\begin{fw_itemize}
+\item ASN.1 Type: $sTasName$ ($sAsnKindName$)
+\item Min size: $sMinBytes$ bytes
+\item Max size: $sMaxBytes$ bytes $sMaxBitsExplained$
+\end{fw_itemize}
+
+$sCommentLine$
+
+\begin{longtable}{|c|c|c|}
+\caption{Type content for $sTasName$}\label{tab:param$sTasNameC$} \\\\
+\hline
+\rowcolor{light-gray}
+\textbf{Constraints} & \textbf{Min Length (bits)} & \textbf{Max Length (bits)} \\\\
+\hline\\hline
+\endfirsthead
+\rowcolor{light-gray}
+\textbf{Constraints} & \textbf{Min Length (bits)} & \textbf{Max Length (bits)} \\\\
+\hline\\hline
+\endhead
+$sAsn1Constraints$ & $sMinBits$ & $sMaxBits$$sMaxBitsExplained$ \\\\
+\hline
+\end{longtable}
+\newpage
+
+>>
+
+
+EmitSequence(sColor, sTasName, sTasNameC, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren, arrsComments) ::= <<
+\subsection{$if(sCommentLine)$$first(arrsComments)$$else$$sTasName$$endif$}\label{sec:ICD_$sTasNameC$}
+
+\begin{fw_itemize}
+\item ASN.1 Type: $sTasName$ (SEQUENCE)
+\item Min size: $sMinBytes$ bytes
+\item Max size: $sMaxBytes$ bytes $sMaxBitsExplained$
+\end{fw_itemize}
+
+\begin{longtable}{|c|p{3cm}|p{5cm}|c|p{3cm}|c|c|c|}
+\caption{Source Data Parameters for $sTasName$}\label{tab:param$sTasNameC$} \\\\
+\hline
+\rowcolor{light-gray}
+\textbf{No} & \textbf{Field} & \textbf{Description} & \textbf{Optional} & \textbf{Type} & \textbf{Constraint} & \textbf{Min} & \textbf{Max} \\\\
+\rowcolor{light-gray}
+ & & & & & & \textbf{Length} & \textbf{Length} \\\\
+\rowcolor{light-gray}
+ & & & & & & \textbf{(bits)} & \textbf{(bits)} \\\\
+\hline\\hline
+\endfirsthead
+\rowcolor{light-gray}
+\textbf{No} & \textbf{Field} & \textbf{Description} & \textbf{Optional} & \textbf{Type} & \textbf{Constraint} & \textbf{Min} & \textbf{Max} \\\\
+\rowcolor{light-gray}
+ & & & & & & \textbf{Length} & \textbf{Length} \\\\
+\rowcolor{light-gray}
+ & & & & & & \textbf{(bits)} & \textbf{(bits)} \\\\
+\hline\\hline
+\endhead
+$arrsChildren;separator="\n\\hline\n"$
+\hline
+\end{longtable}
+\newpage
+>>
+
+EmmitSeqChild_RefType(sRefName, sRefNameC) ::= <<
+$sRefName$~\ref{sec:ICD_$sRefNameC$}
+>>
+
+OddRow() ::= "OddRow"
+EvenRow() ::= "EvenRow"
+
+EmmitSequenceChild(sCssClass, nIndex, sName, sComment, sOptionality, sType, sConstraint, sMin, sMax) ::= <<
+$nIndex$ & $sName$ & $sComment$ & $sOptionality$ & $sType$ & $sConstraint$ & $sMin$ & $sMax$ \\\\
+>>
+
+
+EmmitSequencePreambleSingleComment(nIndex, sOptChildName) ::= <<
+\item bit $nIndex$ == 1 \Rightarrow $sOptChildName$ is present
+>>
+
+EmmitSequencePreambleComment(arrsOptChildren) ::= <<
+Special field used by PER to indicate the presence/absence of optional and default fields.
+\begin{fw_itemize}
+$arrsOptChildren;separator="\n"$
+\end{fw_itemize}
+>>
+
+
+/* *** CHOICE ****/
+EmitChoice(sColor, sTasName, sTasNameC, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsChildren, arrsComments) ::= <<
+\subsection{$if(sCommentLine)$$first(arrsComments)$$else$$sTasName$$endif$}\label{sec:ICD_$sTasNameC$}
+
+\begin{fw_itemize}
+\item ASN.1 Type: $sTasName$ (CHOICE)
+\item Min size: $sMinBytes$ bytes
+\item Max size: $sMaxBytes$ bytes $sMaxBitsExplained$
+\end{fw_itemize}
+
+$if(sCommentLine)$
+$sCommentLine$
+$endif$
+
+\begin{longtable}{|c|p{3cm}|p{5cm}|p{3cm}|c|c|c|}
+\caption{Array content for $sTasName$}\label{tab:param$sTasNameC$} \\\\
+\hline
+\rowcolor{light-gray}
+\textbf{No} & \textbf{Field} & \textbf{Description} & \textbf{Type} & \textbf{Constraint} & \textbf{Min} & \textbf{Max} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{Length} & \textbf{Length} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{(bits)} & \textbf{(bits)} \\\\
+\hline\\hline
+\endfirsthead
+\rowcolor{light-gray}
+\textbf{No} & \textbf{Field} & \textbf{Description} & \textbf{Type} & \textbf{Constraint} & \textbf{Min} & \textbf{Max} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{Length} & \textbf{Length} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{(bits)} & \textbf{(bits)} \\\\
+\hline\\hline
+\endhead
+
+$arrsChildren;separator="\n\\hline\n"$
+
+\hline
+\end{longtable}
+\newpage
+>>
+
+
+EmmitChoiceChild(sCssClass, nIndex, sName, sComment,  sType, sConstraint, sMin, sMax) ::= <<
+$nIndex$ & $sName$ & $sComment$ & $sType$ & $sConstraint$ & $sMin$ & $sMax$ \\\\
+>>
+
+EmmitChoiceIndexSingleComment(nIndex, sChildName) ::= <<
+\item $nIndex$ \Rightarrow $sChildName$
+>>
+
+EmmitChoiceIndexComment(arrsOptChildren) ::= <<
+Special field used by PER to indicate which choice alternative is present.
+\begin{fw_itemize}
+$arrsOptChildren;separator="\n"$
+\end{fw_itemize}
+>>
+
+
+/* *********** CHOICE END ********** */
+/* *********** SEQUENCE OF, OCTET STRING etc ********** */
+EmitSizeable(sColor, sTasName, sTasNameC, sKind, sMinBytes, sMaxBytes, sMaxBitsExplained, sCommentLine, arrsRows, arrsComments) ::= <<
+\subsection{$if(sCommentLine)$$first(arrsComments)$$else$$sTasName$$endif$}\label{sec:ICD_$sTasNameC$}
+
+\begin{fw_itemize}
+\item ASN.1 Type: $sTasName$ ($sKind$)
+\item Min size: $sMinBytes$ bytes
+\item Max size: $sMaxBytes$ bytes $sMaxBitsExplained$
+\end{fw_itemize}
+
+\begin{longtable}{|c|p{3cm}|p{5cm}|p{3cm}|c|c|c|}
+\caption{Array content for $sTasName$}\label{tab:param$sTasNameC$} \\\\
+\hline
+\rowcolor{light-gray}
+\textbf{No} & \textbf{Field} & \textbf{Description} & \textbf{Type} & \textbf{Constraint} & \textbf{Min} & \textbf{Max} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{Length} & \textbf{Length} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{(bits)} & \textbf{(bits)} \\\\
+\hline\\hline
+\endfirsthead
+\rowcolor{light-gray}
+\textbf{No} & \textbf{Field} & \textbf{Description} & \textbf{Type} & \textbf{Constraint} & \textbf{Min} & \textbf{Max} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{Length} & \textbf{Length} \\\\
+\rowcolor{light-gray}
+ & & & & & \textbf{(bits)} & \textbf{(bits)} \\\\
+\hline\\hline
+\endhead
+
+$arrsRows;separator="\n\\hline\n"$
+
+\hline
+\end{longtable}
+\newpage
+>>
+
+EmitRowWith3Dots() ::= <<
+\multicolumn{7}{c|}{. . .} \\\\
+>>
+
+
+/* *********** end of SEQUENCE OF, OCTET STRING etc ********** */
+
+EmmitTass(sTypeContent) ::= <<
+$sTypeContent$
+>>
+
+/* Module - mapped to a Latex section */
+EmmitModule(sModName, arrsComments, arrsTases) ::= <<
+%=============================================================================
+\section{$sModName$}\label{sec:$sModName$}
+$arrsComments;separator="\n"$
+%-----------------------------------------------------------------------------
+$arrsTases;separator="\n"$
+>>
+
+/* File - Collection of modules */
+EmmitFile(sAsnFileName, arrsModules) ::= <<
+% ---- ASN.1 File : $sAsnFileName$ ----
+$arrsModules;separator="\n"$
+>>
+
+/* Part 2 is the ASN.1 model itself with HTML syntax colouring */
+EmmitFilePart2(sFileName, sAsn1Content) ::= <<
+% File: $sFileName$
+% sAsn1Content 
+>>
+
+RootHtml(arrsFiles1, arrsFiles2, bIntegerSizeMustBeExplained, bRealSizeMustBeExplained, bLengthSizeMustBeExplained, bWithComponentMustBeExplained, bZeroBitsMustBeExplained) ::= <<
+The following tables describe the binary encodings of the data model using the ASN.1 Unaligned Packed Encoding Rules
+$arrsFiles1;separator="\n"$
+
+$if(bIntegerSizeMustBeExplained)$
+\label{app:INT_SIZE_EXPLAINED123}
+Unconstraint integer's size explained
+In unaligned PER, unconstraint integers are encoded into the minimum number of octets (using non negative binary integer or 2's-complement binary integer encoding) and a length determinant, containing the number of value octets, is added at the beginning of the encoding. Therefore uPER can support integers of any size, even of infinity value. However, in almost all processors, integers have limited capacity which is usually four or eight octets. Therefore, the reported maximum size in octets for an unconstraint integer is 1 (for the length determinant) plus the word size for the target processor which is specified in the command line by the wordSize argument. In this invocation, wordSize was specified to be 8 octets and therefore the maximum size of the unconstraint integers is 9 octets or 72 bits
+$endif$
+$if(bRealSizeMustBeExplained)$
+\label{app:REAL_SIZE_EXPLAINED123}
+Real's size explained
+In both uPER and aPER, real values are encoded as a pair of integers which represent the mantissa and exponent (real value = mantissa* 2<span style="vertical-align: super">exponent</span>). In particular, a real is encoded into a length determinant field, a header field (always one octet), the exponent field using 2's complement binary integer and the mantissa field. Therefore uPER can support reals with infinity precision since both exponent and mantissa can, theoretically, have infinity length. However, in almost all processors, integers have limited capacity which is usually four or eight octets. Therefore, the reported maximum size in octets for a real is 1 for the length determinant plus 1 for header field plus 3 octets for exponent and finally plus the word size for the target processor which is specified in the command line by the wordSize argument. In this invocation, wordSize was specified to be 8 octets and therefore the maximum size of a real is 13 octets or 104 bits.
+$endif$
+$if(bLengthSizeMustBeExplained)$
+\label{app:ARRAYS_SIZE_EXPLAINED123}
+Length's size explained
+In uPER, the length determinant field, which used in the encoding of sizeable types such as SEQUENCE OFs, SET OFs, BIT STRINGs, OCTET STRINGs and character types, is at most two octets provided that (a) there is a SIZE constraint which limits the length count to a value less than 64K or (b) there is no size constraint, but in the given instance of the sizeable type the number of the elements is less than 16K. In all other cases, the sizeable type is encoded using fragmentation where the length determinant is encoded interstitially with the actual data. In this particular case (i.e. when fragmentation is applicable), the table produced by the autoICD generator does not represent correctly the physical PER encoding.
+$endif$
+$if(bWithComponentMustBeExplained)$
+\label{app:WITH_COMPONENT_EXPLAINED123}
+Constraint ignored in encoding
+The constraint with the yellow color is not PER visible, as it derives from a WITH COMPONENT or WITH COMPONENTS contraint in the parent type, and therefore is ignored in the encoding/decoding.
+$endif$
+$if(bZeroBitsMustBeExplained)$
+\label{app:ZERO_BITS_EXPLAINED123}
+Field with zero size explained
+An integer type that is contraint to a single value (i.e. INTEGER (5) or INTEGER (1..10)(10..20)) requires zero bits when encoded in uPER since the decoder can always determine its value. In other words, a integer field which is contraint to a single value is never transmitted in uPER.
+$endif$
+
+$arrsFiles2;separator="\n"$
+>>
+
+

--- a/contrib/prepare_debian_package.sh
+++ b/contrib/prepare_debian_package.sh
@@ -2,7 +2,7 @@
 INITIAL_FOLDER=$(pwd)
 cd ..
 VERSION=$(cat Asn1f2/SvnVersion.cs | cut -d \" -f 2)
-echo Creating a Debian package for ASN1Scc version 3.0.$VERSION
+echo Creating a Debian package for ASN1Scc version 3.1.$VERSION
 test -f Asn1f2/bin/Debug/Asn1f2.exe || (echo 'Run ./build.sh first to build ASN1SCC' && false)
 rm -rf asn1scc
 mkdir -p asn1scc/DEBIAN


### PR DESCRIPTION
Icd Generator updates, raising tool version to 3.1 because of the following API changes:

- new  ItemNumber() production in the template files 
- new  arrsComments parameter in top-level type templates