### PR TITLE
build fixes for mono4

### DIFF
--- a/AntlrUtils/AntlrUtils.fsproj
+++ b/AntlrUtils/AntlrUtils.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -49,8 +49,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/Ast/Ast.fsproj
+++ b/Ast/Ast.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -86,8 +86,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/Backend.c.ST/Backend.c.ST.fsproj
+++ b/Backend.c.ST/Backend.c.ST.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -98,8 +98,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>
@@ -107,7 +122,7 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-    <Choose>
+  <Choose>
     <When Condition="$(OS) == 'Unix'">
       <PropertyGroup>
         <MonoCallPrefix> mono </MonoCallPrefix>

--- a/Backend.c/Backend.c.fsproj
+++ b/Backend.c/Backend.c.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -85,8 +85,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/Backend2.ST/Backend2.ST.fsproj
+++ b/Backend2.ST/Backend2.ST.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,8 +36,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/Backend2/Backend2.fsproj
+++ b/Backend2/Backend2.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -91,8 +91,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>

--- a/ST/ST.fsproj
+++ b/ST/ST.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,8 +40,23 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) == 'Unix'">
       <PropertyGroup>
-        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+        <FSharpTargetsPath45>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.5\Microsoft.FSharp.Targets</FSharpTargetsPath45>
       </PropertyGroup>
+      <PropertyGroup>
+        <FSharpTargetsPath40>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath40>
+      </PropertyGroup>
+      <Choose>
+        <When Condition="Exists('$(FSharpTargetsPath45)')">
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath45)</FSharpTargetsPath>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <FSharpTargetsPath>$(FSharpTargetsPath40)</FSharpTargetsPath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
     <Otherwise>
       <PropertyGroup>


### PR DESCRIPTION
After updating to Mono 4.0.1 I had problems compiling F# modules - turns out Mono updated F# framework and references in fsproj files needs to be updated. I tried to keep existing functionality, yet it makes fsproj files a little bit complicated. 