### PR TITLE
removed some warnings in generated C code (detected by clang)

### DIFF
--- a/Backend.c.ST/c_aux.stg
+++ b/Backend.c.ST/c_aux.stg
@@ -183,6 +183,7 @@ int main(int argc, char* argv[])
     };
 
 }
+
 >>
 
 /*

--- a/asn1crt/asn1crt.c
+++ b/asn1crt/asn1crt.c
@@ -828,10 +828,11 @@ flag DecodeRealUsingDecimalEncoding(BitStream* pBitStrm, int length, byte header
 {
     ASSERT_OR_RETURN_FALSE(0);
 
-    pBitStrm = pBitStrm;
-    length = length;
-    header = header;
-    v = v;
+    (void) pBitStrm;
+    (void) length;
+    (void) header;
+    (void) v;
+
     return FALSE;
 }
 


### PR DESCRIPTION
Clang was detecting "self assign" and "missing newline at end of file"
warnings