### PR TITLE
generated C code produces warnings on older gcc

### DIFF
--- a/asn1crt/asn1crt.c
+++ b/asn1crt/asn1crt.c
@@ -664,7 +664,7 @@ void BitStream_EncodeReal(BitStream* pBitStrm, double v)
     byte header=0x80;
     int nExpLen;
     int nManLen;
-    int exp;
+    int exponent;
     asn1SccUint mantissa;
 
 
@@ -692,8 +692,8 @@ void BitStream_EncodeReal(BitStream* pBitStrm, double v)
         v=-v;
     }
 
-    CalculateMantissaAndExponent(v, &exp, &mantissa);
-    nExpLen = GetLengthInBytesOfSInt(exp);
+    CalculateMantissaAndExponent(v, &exponent, &mantissa);
+    nExpLen = GetLengthInBytesOfSInt(exponent);
     nManLen = GetLengthInBytesOfUInt(mantissa);
     assert(nExpLen<=3);
     if (nExpLen == 2)
@@ -709,13 +709,13 @@ void BitStream_EncodeReal(BitStream* pBitStrm, double v)
     BitStream_EncodeConstraintWholeNumber(pBitStrm, header, 0, 0xFF);
 
     /* encode exponent */
-    if (exp>=0) {
-        BitStream_AppendNBitZero(pBitStrm,nExpLen*8-GetNumberOfBitsForNonNegativeInteger((asn1SccUint)exp));
-        BitStream_EncodeNonNegativeInteger(pBitStrm,(asn1SccUint)exp);
+    if (exponent>=0) {
+        BitStream_AppendNBitZero(pBitStrm,nExpLen*8-GetNumberOfBitsForNonNegativeInteger((asn1SccUint)exponent));
+        BitStream_EncodeNonNegativeInteger(pBitStrm,(asn1SccUint)exponent);
     }
     else {
-        BitStream_AppendNBitOne(pBitStrm,nExpLen*8-GetNumberOfBitsForNonNegativeInteger((asn1SccUint)(-exp-1)));
-        BitStream_EncodeNonNegativeIntegerNeg(pBitStrm,(asn1SccUint)(-exp-1), 1);
+        BitStream_AppendNBitOne(pBitStrm,nExpLen*8-GetNumberOfBitsForNonNegativeInteger((asn1SccUint)(-exponent-1)));
+        BitStream_EncodeNonNegativeIntegerNeg(pBitStrm,(asn1SccUint)(-exponent-1), 1);
     }
 
 
@@ -770,7 +770,7 @@ flag DecodeRealAsBinaryEncoding(BitStream* pBitStrm, int length, byte header, do
     int F;
     unsigned factor=1;
     int expLen;
-    int exp = 0;
+    int exponent = 0;
     int expFactor = 1;
     asn1SccUint N=0;
     int i;
@@ -800,9 +800,9 @@ flag DecodeRealAsBinaryEncoding(BitStream* pBitStrm, int length, byte header, do
             return FALSE;
         if (!i) {
             if (b>0x7F)
-                exp=-1;
+                exponent=-1;
         }
-        exp = exp<<8 | b;
+        exponent = exponent<<8 | b;
     }
     length-=expLen;
 
@@ -815,7 +815,7 @@ flag DecodeRealAsBinaryEncoding(BitStream* pBitStrm, int length, byte header, do
 
 
 //  *v = N*factor * pow(base,exp);
-    *v = GetDoubleByMantissaAndExp(N*factor, expFactor*exp);
+    *v = GetDoubleByMantissaAndExp(N*factor, expFactor*exponent);
 
     if (sign<0)
         *v = -(*v);

--- a/asn1crt/real.c
+++ b/asn1crt/real.c
@@ -26,32 +26,25 @@
 #define MantBitMask  0x000FFFFFFFFFFFFFULL
 #define MantBitMask2 0xFFE0000000000000ULL
 
-void CalculateMantissaAndExponent(double d, int* exp, asn1SccUint* mantissa)
+void CalculateMantissaAndExponent(double d, int* exponent, asn1SccUint* mantissa)
 {
-    //double dman = frexp(d,exp);
-    //*mantissa = (asn1SccUint)(MANTISSA_FACTOR*dman);
-    //(*exp) -= EXPONENET_FACTOR;
-
-
-    asn1SccUint *pl = NULL;
+    asn1SccUint* pl = NULL;
     asn1SccUint ll = 0;
 
-    *exp = 0;
+    *exponent = 0;
     *mantissa = 0;
 
     pl = (asn1SccUint*)&d;
 
     ll = *pl;
 
-
-    *exp = (int)(((ll & ExpoBitMask)>>52) - 1023 - 52);
+    *exponent = (int)(((ll & ExpoBitMask)>>52) - 1023 - 52);
 
     *mantissa = ll & MantBitMask;
     (*mantissa) |= 0x0010000000000000ULL;
-
 }
 
-double GetDoubleByMantissaAndExp(asn1SccUint mantissa, int exp)
+double GetDoubleByMantissaAndExp(asn1SccUint mantissa, int exponent)
 {
     union {
         double ret;
@@ -59,7 +52,7 @@ double GetDoubleByMantissaAndExp(asn1SccUint mantissa, int exp)
     } u;
    
     asn1SccUint ll = 0;
-    asn1SccUint exp2 = 0; 
+    asn1SccUint exponent2 = 0; 
 
     if (mantissa == 0)
         return 0.0;
@@ -67,19 +60,19 @@ double GetDoubleByMantissaAndExp(asn1SccUint mantissa, int exp)
 
     while ( (mantissa & MantBitMask2)>0) {
         mantissa>>=1;
-        exp += 1;
+        exponent += 1;
     }
     while ( (mantissa & 0x0010000000000000ULL) == 0) {
         mantissa<<=1;
-        exp += -1;
+        exponent += -1;
     }
 
 
-    exp2 = (asn1SccUint)(exp + 1023 + 52);
+    exponent2 = (asn1SccUint)(exponent + 1023 + 52);
 
 
     ll |= mantissa & MantBitMask;
-    ll |= (exp2<<52);
+    ll |= (exponent2<<52);
 
     u.u64 = ll;
 


### PR DESCRIPTION
gcc 4.4 with option -Wshadow complains about 'exp' and 'exp2' variables
shadowing functions from math.h