### PR TITLE
asn1crt: new versions of MSVC define INFINITY & NAN macros

### DIFF
--- a/asn1crt/asn1crt.h
+++ b/asn1crt/asn1crt.h
@@ -50,8 +50,12 @@ typedef asn1SccSint32 asn1SccSint;
 #endif
 
 #ifdef _MSC_VER
-#define INFINITY (DBL_MAX+DBL_MAX)
-#define NAN (INFINITY-INFINITY)
+#  ifndef INFINITY
+#    define INFINITY (DBL_MAX+DBL_MAX)
+#  endif
+#  ifndef NAN
+#    define NAN (INFINITY-INFINITY)
+#  endif
 #endif
 
 typedef bool flag;


### PR DESCRIPTION
redefinition causes warnings