### PR TITLE
Comments starting with --! will be ignored during ICD generation

### DIFF
--- a/Antlr/Comments.cs
+++ b/Antlr/Comments.cs
@@ -39,8 +39,9 @@ namespace Antlr
                 }
                 else if (t.Type == COMMENT || t.Type == COMMENT2)
                 {
+                    if (!t.Text.StartsWith("--!"))
                         comments.Insert(0, t.Text);
-                        alreadyTakenComments.Add(t);
+                    alreadyTakenComments.Add(t);
                 }
                 else
                 {
@@ -62,8 +63,9 @@ namespace Antlr
                         continue;
                     else if (t.Type == COMMENT || t.Type == COMMENT2)
                     {
+                        if (!t.Text.StartsWith("--!"))
                             comments.Insert(0, t.Text);
-                            alreadyTakenComments.Add(t);
+                        alreadyTakenComments.Add(t);
                     }
                     else
                         break;


### PR DESCRIPTION
Problems starts, when ASN.1 or ACN files requires some additional license comments at beginning of file. Now some special comments "--!" will no longer be gathered for types.