### PR TITLE
ICD ACN: fixed layout of "SEQUENCE OF/STRING" tables

### DIFF
--- a/Backend2.ST/icd_acn.stg
+++ b/Backend2.ST/icd_acn.stg
@@ -296,7 +296,7 @@ $sTasName$ <font size="-1">($if(bIsAnonymousType)$<i>anonymous </i>$endif$$sKind
 
 $if(sCommentLine)$
 <tr class="CommentRow">
-<td class="comment2" colspan="8">$sCommentLine$</td>
+<td class="comment2" colspan="7">$sCommentLine$</td>
 </tr>
 $endif$
 


### PR DESCRIPTION
When comment was present, its row had too big colspan, breaking table
display in some browsers.