### PR TITLE
Removed non-standard header from autogenerated C test cases

### DIFF
--- a/Backend.c.ST/c_aux.stg
+++ b/Backend.c.ST/c_aux.stg
@@ -166,7 +166,7 @@ flag <sTasName>_<sEnc>enc_dec(const <sTasName><sStar> pVal, int* pErrCode)
 
 PrintMain_testCases(arrsIncludedModules, arrsTestFunctions) ::= <<
 #include \<stdio.h>
-#include \<memory.h>
+#include \<string.h>
 #include \<math.h>
 #include \<float.h>
 #include \<limits.h>


### PR DESCRIPTION
memory.h is not a standard C header (and is not present on some
compilers distributions), string.h will be included instead