### PR TITLE
C ACN generator - removed dead assignments

### DIFF
--- a/Backend.c.ST/c_acn.stg
+++ b/Backend.c.ST/c_acn.stg
@@ -479,7 +479,7 @@ str_FixedSize_encode(p, i, sInternalItem, nFixedSize) ::= <<
 str_FixedSize_decode(p, i, sInternalItem, nFixedSize) ::= <<
 {
     asn1SccSint charIndex;
-    *pErrCode = 0; ret = TRUE;
+    *pErrCode = 0;
     memset(<p>, 0x0, <nFixedSize>+1);
     <loopFixedItem(i=i, sInternalItem=sInternalItem, fixedSize=nFixedSize)>
 }
@@ -654,7 +654,7 @@ Sequence_encode(sChildren, bHasUperOptionalChildren, nUperOptionalChildrenLength
 
 
 Sequence_decode(sChildren, bHasUperOptionalChildren, nUperOptionalChildrenLength, sBitMaskName) ::= <<
-*pErrCode = 0; ret = TRUE;
+*pErrCode = 0;
 <if(bHasUperOptionalChildren)>
 /* Decode Bit Mask for optional and default fields*/
 ret = BitStream_ReadBits(pBitStrm, <sBitMaskName>, <nUperOptionalChildrenLength>);
@@ -757,7 +757,7 @@ default:
 >>
 
 Choice_preWhen_decode(p, arrsChildren, sErrCode) ::= <<
-*pErrCode = 0; ret = TRUE;
+*pErrCode = 0;
 <arrsChildren; separator="\n">
 else {
     *pErrCode = ERR_INVALID_CHOICE_ALTERNATIVE;         //COVERAGE_IGNORE

--- a/Backend.c.ST/c_aux.stg
+++ b/Backend.c.ST/c_aux.stg
@@ -131,7 +131,7 @@ flag <sTasName>_<sEnc>enc_dec(const <sTasName><sStar> pVal, int* pErrCode)
     static <sTasName> decodedPDU;
     static byte encBuff[<sTasName>_REQUIRED_BYTES_FOR_<sEnc>ENCODING + 1]; /* +1 for zerosized types */
     BitStream bitStrm;
-    flag ret;
+    flag ret = TRUE;
     <arrsEncInDecOutParamsLocalVars; separator="\n">
     <arrsDecInParamLocalVars; separator="\n">
 
@@ -147,7 +147,7 @@ flag <sTasName>_<sEnc>enc_dec(const <sTasName><sStar> pVal, int* pErrCode)
     static <sTasName> decodedPDU;
     static byte encBuff[<sTasName>_REQUIRED_BYTES_FOR_<sEnc>ENCODING + 1]; /* +1 for zerosized types */
     ByteStream bitStrm;
-    flag ret;
+    flag ret = TRUE;
     <arrsEncInDecOutParamsLocalVars; separator="\n">
     <arrsDecInParamLocalVars; separator="\n">
 


### PR DESCRIPTION
static code analysis revealed that `ret = TRUE;` assignments are not
necessary, as `ret` is usually initialized to `TRUE` on its declaration
and then assigned `FALSE` on error.

This commits ensures all `flag ret` declarations also define it value
and removed `ret = TRUE` assignments.