### PR TITLE
asn1crt - fixed undefined behavior when using some BER tags

### DIFF
--- a/asn1crt/ber.c
+++ b/asn1crt/ber.c
@@ -104,7 +104,9 @@ flag BerDecodeTag(ByteStream* pByteStrm, BerTag tag, int *pErrCode) {
     BerTag PrimitiveBit=0;
     byte curByte=0;
 
-
+    if(tgCopy==0) {
+      tagSize = 1;
+    }
     while(tgCopy>0) {
         tgCopy>>=8;
         tagSize++;


### PR DESCRIPTION
static analysis tool (scan-build) reported that for BerTag == 0 method
BerDecodeTag might act in undefined way (shift by negative number of
bits).

BER tag zero is reserved and should not be used. Yet I assumed
BerDecodeTag should still be able to read it.