### PR TITLE
Custom output of unit tests

### DIFF
--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -363,7 +363,8 @@ namespace Asn1f2
                     var vas = "ALL";
 
                     automatic_test_cases.CreateTestCases(astForBackend, acnAst3, outDir);
-                    automatic_test_cases.CreateMainFile(astForBackend, acnAst3, outDir, vas);
+                    automatic_test_cases.CreateTestSuiteFile(astForBackend, acnAst3, outDir, vas);
+                    automatic_test_cases.CreateMainFile(outDir);
                     automatic_test_cases.CreateMakeFile(astForBackend, acnAst3, outDir);
                 }
 

--- a/Backend.c.ST/c_aux.stg
+++ b/Backend.c.ST/c_aux.stg
@@ -169,12 +169,48 @@ PrintMain(sTestSuiteFilename) ::= <<
 
 #include "<sTestSuiteFilename>.h"
 
+static void printf_tests_failed(int testCount, int failedCount)
+{
+    printf("%d out of %d failed.\n", failedCount, testCount);
+}
+
+static void printf_tests_passed(int testCount)
+{
+    printf("All test cases (%d) run successfully.\n", testCount);
+}
+
+static void printf_null()
+{
+}
+
+static void printf_null_char(const char* s)
+{
+    (void)s;
+}
+
+static void printf_message(const char* message)
+{
+    printf("%s\n", message);
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
     (void)argv;
 
-    return asn1scc_run_generated_testsuite();
+    TestOutput output = {
+               .report_tests_failed = printf_tests_failed,
+               .report_all_tests_passed = printf_tests_passed,
+               .report_suite_begin = printf_null,
+               .report_suite_end = printf_null,
+               .report_case_begin = printf_null_char,
+               .report_case_end = printf_null,
+               .report_failure_begin = printf_null,
+               .report_failure_end = printf_null,
+               .report_failure_message = printf_message
+    };
+
+    return asn1scc_run_generated_testsuite(&output);
 }
 
 >>
@@ -184,38 +220,45 @@ Code calling a test case
 */
 PrintSuite_call_codec(sTasName, sAmber, sEnc, sValue, sValueAsAsn1, sVasName, bStatic, sGenerateDatFile) ::= <<
 {
+    output->report_case_begin("<sTasName>_<sEnc>enc_dec");
+
     {
         // dummy statement used for calling init functions
         <if(bStatic)>static <endif><sTasName> tmp0;
         <sTasName>_Initialize(<sAmber>tmp0);
     }
-    <if(bStatic)>static <endif><sTasName> tmp = 
+    <if(bStatic)>static <endif><sTasName> tmp =
         <sValue>;
-		
-	result = <sTasName>_<sEnc>enc_dec(<sAmber>tmp, &errCode);
-	if (!result) {
-		switch(errCode)
-		{
-		case 1:
-			printf("Test case <sVasName> failed in encoding\n");
-			break;
-		case 2:
-			printf("Test case '<sVasName>' failed in decoding\n");
-			break;
-		case 3:
-			printf("Test case '<sVasName>' failed in the validation of the decoded message\n");
-			break;
-		case 4:
-			printf("Test case '<sVasName>' failed. Encoded and decoded messages are different\n");
-			break;
-		default:
-			printf("Unexpected error code in test case '<sVasName>'\n");
-		}
-		printf("Test Value was <sValueAsAsn1>\n");
-		printf("========================================\n");
-		totalErrors = totalErrors + 1;
-	};
+        result = <sTasName>_<sEnc>enc_dec(<sAmber>tmp, &errCode);
+        if (!result) {
+           output->report_failure_begin();
+
+           switch(errCode)
+           {
+           case 1:
+                output->report_failure_message("Test case <sVasName> failed in encoding.");
+                break;
+           case 2:
+                output->report_failure_message("Test case '<sVasName>' failed in decoding.");
+                break;
+           case 3:
+                output->report_failure_message("Test case '<sVasName>' failed in the validation of the decoded message.");
+                break;
+           case 4:
+                output->report_failure_message("Test case '<sVasName>' failed. Encoded and decoded messages are different.");
+                break;
+           default:
+                output->report_failure_message("Unexpected error code in test case '<sVasName>'.");
+           }
+           output->report_failure_message("Test Value was <sValueAsAsn1>");
+           output->report_failure_message("========================================");
+           totalErrors = totalErrors + 1;
+
+           output->report_failure_end();
+        }
     <sGenerateDatFile>
+
+    output->report_case_end();
 }
 >>
 
@@ -294,7 +337,22 @@ PrintTestSuiteHeader() ::= <<
 #ifndef GENERATED_ASN1SCC_TESTSUITE_H
 #define GENERATED_ASN1SCC_TESTSUITE_H
 
-int asn1scc_run_generated_testsuite(void);
+typedef struct {
+    void (*report_tests_failed)(int testsCount, int failedCount);
+    void (*report_all_tests_passed)(int testsCount);
+
+    void (*report_suite_begin)();
+    void (*report_suite_end)();
+
+    void (*report_case_begin)(const char* caseName);
+    void (*report_case_end)();
+
+    void (*report_failure_begin)();
+    void (*report_failure_end)();
+    void (*report_failure_message)(const char* message);
+} TestOutput;
+
+int asn1scc_run_generated_testsuite(TestOutput* output);
 
 #endif // GENERATED_ASN1SCC_TESTSUITE_H
 >>
@@ -310,22 +368,25 @@ PrintTestSuiteSource(sTestSuiteFilename, arrsIncludedModules, arrsTestFunctions)
 
 #include "asn1crt.h"
 
-
 <arrsIncludedModules:{inc| #include "<inc>.h"}; separator="\n">
 
-int asn1scc_run_generated_testsuite()
+int asn1scc_run_generated_testsuite(TestOutput* output)
 {
     int totalErrors = 0;
     flag result;
     int errCode;
 
+    output->report_suite_begin();
+
     <arrsTestFunctions;separator="\n\n">
 
+    output->report_suite_end();
+
     if (totalErrors > 0 ) {
-        printf("%d out of <arrsTestFunctions.Length> failed.", totalErrors);
+        output->report_tests_failed(<arrsTestFunctions.Length>, totalErrors);
         return 1;
     } else {
-        printf("All test cases (<arrsTestFunctions.Length>) run successfully.");
+        output->report_all_tests_passed(<arrsTestFunctions.Length>);
         return 0;
     }
 }

--- a/Backend.c.ST/c_aux.stg
+++ b/Backend.c.ST/c_aux.stg
@@ -164,35 +164,17 @@ flag <sTasName>_<sEnc>enc_dec(const <sTasName><sStar> pVal, int* pErrCode)
 /* Encode Decode End*/
 
 
-PrintMain_testCases(arrsIncludedModules, arrsTestFunctions) ::= <<
+PrintMain(sTestSuiteFilename) ::= <<
 #include \<stdio.h>
-#include \<string.h>
-#include \<math.h>
-#include \<float.h>
-#include \<limits.h>
-#include "asn1crt.h"
 
-<arrsIncludedModules:{inc| #include "<inc>.h"}; separator="\n">
+#include "<sTestSuiteFilename>.h"
 
 int main(int argc, char* argv[])
 {
-	(void)argc;
-	(void)argv;
+    (void)argc;
+    (void)argv;
 
-	int totalErrors = 0;
-	flag result;
-	int errCode;
-
-	<arrsTestFunctions;separator="\n\n">
-
-    if (totalErrors > 0 ) {
-        printf("%d out of <arrsTestFunctions.Length> failed.", totalErrors); 
-        return 1;
-    } else {
-        printf("All test cases (<arrsTestFunctions.Length>) run successfully."); 
-        return 0;
-    };
-
+    return asn1scc_run_generated_testsuite();
 }
 
 >>
@@ -200,7 +182,7 @@ int main(int argc, char* argv[])
 /*
 Code calling a test case
 */
-PrintMain_call_codec(sTasName, sAmber, sEnc, sValue, sValueAsAsn1, sVasName, bStatic, sGenerateDatFile) ::= <<
+PrintSuite_call_codec(sTasName, sAmber, sEnc, sValue, sValueAsAsn1, sVasName, bStatic, sGenerateDatFile) ::= <<
 {
     {
         // dummy statement used for calling init functions
@@ -238,7 +220,7 @@ PrintMain_call_codec(sTasName, sAmber, sEnc, sValue, sValueAsAsn1, sVasName, bSt
 >>
 
 
-PrintMain_call_codec_generate_dat_file(sTasName, sAmber, sEnc, sStreamName) ::= <<
+PrintSuite_call_codec_generate_dat_file(sTasName, sAmber, sEnc, sStreamName) ::= <<
 	if (result) {
 		static byte encBuff[<sTasName>_REQUIRED_BYTES_FOR_<sEnc>ENCODING + 1]; /* +1 for zerosized types */
 		<sStreamName>Stream bitStrm;
@@ -308,3 +290,44 @@ clean:
 	@rm -rf *.o $(TARGET) *.gcda *.gcno *.gcov
 >>
 
+PrintTestSuiteHeader() ::= <<
+#ifndef GENERATED_ASN1SCC_TESTSUITE_H
+#define GENERATED_ASN1SCC_TESTSUITE_H
+
+int asn1scc_run_generated_testsuite(void);
+
+#endif // GENERATED_ASN1SCC_TESTSUITE_H
+>>
+
+PrintTestSuiteSource(sTestSuiteFilename, arrsIncludedModules, arrsTestFunctions) ::= <<
+#include "<sTestSuiteFilename>.h"
+
+#include \<stdio.h>
+#include \<string.h>
+#include \<math.h>
+#include \<float.h>
+#include \<limits.h>
+
+#include "asn1crt.h"
+
+
+<arrsIncludedModules:{inc| #include "<inc>.h"}; separator="\n">
+
+int asn1scc_run_generated_testsuite()
+{
+    int totalErrors = 0;
+    flag result;
+    int errCode;
+
+    <arrsTestFunctions;separator="\n\n">
+
+    if (totalErrors > 0 ) {
+        printf("%d out of <arrsTestFunctions.Length> failed.", totalErrors);
+        return 1;
+    } else {
+        printf("All test cases (<arrsTestFunctions.Length>) run successfully.");
+        return 0;
+    }
+}
+
+>>


### PR DESCRIPTION
I've changed a little bit generated C auto cases, to allow users to provide custom output formatter (I was able to produce required XML in xUnit style output and integrate with reporting system). Default output formatter produces exactly same results as original.

This change also allows users to run tests without using `main` function generated by `asn1scc`. Might be useful for running tests in some embedded environments. 