### PR TITLE
fixed missing new line in generated C headers

### DIFF
--- a/Backend.c.ST/c_aux.stg
+++ b/Backend.c.ST/c_aux.stg
@@ -355,6 +355,7 @@ typedef struct {
 int asn1scc_run_generated_testsuite(TestOutput* output);
 
 #endif // GENERATED_ASN1SCC_TESTSUITE_H
+
 >>
 
 PrintTestSuiteSource(sTestSuiteFilename, arrsIncludedModules, arrsTestFunctions) ::= <<


### PR DESCRIPTION
Really small fix, removes clang warning in generated code