### PR TITLE
[WIP] Switch from xbuild to msbuild

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ done
 set -e
 MAIN_FOLDER="$(pwd)"
 cd parseStg2/
-xbuild
+msbuild
 cd ../
 cd Backend.c.ST/
 mono ../parseStg2/bin/Debug/parseStg2.exe backends.xml
@@ -33,9 +33,9 @@ OEF
 fi
 grep PreBuildEvent Asn1f2.csproj >/dev/null && grep -v TargetFrameworkProfile Asn1f2.csproj | awk 'BEGIN{i=0} /<PreBuildEvent/{i=1;}  {if (i== 0) { print $0; }}  /<\/PreBuildEvent?/{i=0;}' > a && mv a Asn1f2.csproj
 cd ../Antlr
-xbuild || exit 1
+msbuild || exit 1
 cd "$MAIN_FOLDER"
-xbuild || exit 1
+msbuild || exit 1
 cd Asn1f2/
 mkdir -p bin/Debug/
 cp ../*/*.stg bin/Debug/

--- a/circleci-build.sh
+++ b/circleci-build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-xbuild /p:TargetFrameworkVersion="v4.5" || exit 1
+msbuild /p:TargetFrameworkVersion="v4.5" || exit 1
 cd Tests || exit 1
 make || exit 1


### PR DESCRIPTION
**This PR is a WIP on the msbuild migration, for CI testing, feedback and discussion.**

Recent xbuild versions give the warning:  
`>>>> xbuild tool is deprecated and will be removed in future updates, use msbuild instead <<<<
`

