### PR TITLE
Replace Seq.nth by Seq.item

### DIFF
--- a/Ast/Acn.fs
+++ b/Ast/Acn.fs
@@ -786,7 +786,7 @@ module Resolve =
                             let prms = acn.Parameters |> List.filter(fun x -> x.ModName = md.Value && x.TasName=ts.Value) 
                             match argIndex < (Seq.length prms)  with
                                           | false   -> raise(FsUtils.SemanticError(r.Location, "Too many arguments"))
-                                          | true    -> (Seq.nth argIndex prms).Name
+                                          | true    -> (Seq.item argIndex prms).Name
                         | _                     -> raise(BugErrorException("Expecting Reference Type"))
                     RefTypeArgument prm
                 | _                     -> r.Kind

--- a/Backend.c/c_uper.fs
+++ b/Backend.c/c_uper.fs
@@ -23,7 +23,7 @@ open c_utils
 
 
 let rec EmitInternalItem_min_max (t:Asn1Type) (sTasName:string) (path:list<string>)  (m:Asn1Module) (r:AstRoot)  codec =
-    let sTasName = GetTasCName (path |> Seq.nth 1) r.TypePrefix
+    let sTasName = GetTasCName (path |> Seq.item 1) r.TypePrefix
     let p = match codec with
             | Encode -> GetTypeAccessPath path r
             | Decode -> GetTypeAccessPathPtr path  r 

--- a/Backend.c/c_validate.fs
+++ b/Backend.c/c_validate.fs
@@ -177,7 +177,7 @@ let rec EmitTypeBody (t:ConstraintType) (path:list<string>)  (m:Asn1Module) (r:A
             c_src.Emit_choice_child (c.CName_Present C) sChildBody
 
         let arrChildren = children |> List.map printChild 
-        let sTasName = GetTasCName (path |> Seq.nth 1) r.TypePrefix
+        let sTasName = GetTasCName (path |> Seq.item 1) r.TypePrefix
         c_src.Emit_choice p arrChildren (GetChoiceErrorCode path r)
     |SequenceOf(child) -> 
         let min, max = SizeableTypeUperRange t.Type.Kind t.Type.Constraints

--- a/Backend2/spark_uper.fs
+++ b/Backend2/spark_uper.fs
@@ -22,7 +22,7 @@ open spark_utils
 
 
 let rec EmitInternalItem_min_max (t:Asn1Type) (sTasName:string) (path:list<string>)  (m:Asn1Module) (r:AstRoot)  codec =
-    let sTasName = GetTasCName (path |> Seq.nth 1) r.TypePrefix
+    let sTasName = GetTasCName (path |> Seq.item 1) r.TypePrefix
     let p = GetAccessFld path (Same t) r 
     match t.Kind with
     | SequenceOf(_) | OctetString | BitString->
@@ -51,7 +51,7 @@ let rec EmitInternalItem_min_max (t:Asn1Type) (sTasName:string) (path:list<strin
     | _     ->raise(BugErrorException "")
 
 and  EmitTypeBody (t:Asn1Type) (sTasName:string) (path:list<string>, pName:string option)  (m:Asn1Module) (r:AstRoot)  codec =
-    //let sTasName = GetTasCName (path |> Seq.nth 1) r.TypePrefix
+    //let sTasName = GetTasCName (path |> Seq.item 1) r.TypePrefix
     let p = match pName with
             | Some(nm)  -> nm
             | None      -> GetAccessFld path (Same t) r 

--- a/Backend2/spark_validate.fs
+++ b/Backend2/spark_validate.fs
@@ -180,7 +180,7 @@ let rec EmitTypeBody (t:ConstraintType) (path:list<string>)  (tasList:list<(List
             sc.Emit_choice_child (c.CName ProgrammingLanguage.Spark) sChildBody (c.CName_Present Spark)
 
         let arrChildren = children |> List.map printChild 
-        let sTasName = GetTasCName (path |> Seq.nth 1) r.TypePrefix
+        let sTasName = GetTasCName (path |> Seq.item 1) r.TypePrefix
         sc.Emit_choice sTasName arrChildren
     |SequenceOf(child) -> 
         let min, max = SizeableTypeUperRange t.Type.Kind t.Type.Constraints


### PR DESCRIPTION
Seq.nth was deprecated in F# 4.0

This is the same (save for the replace in comment) as the commit reverted by https://github.com/ttsiodras/asn1scc/commit/d8c6603bd8352064f64d1dc9c3b3122a26bbab15