### PR TITLE
fixed compilation after using wildcards in csproj files

### DIFF
--- a/Asn1f2/Asn1f2.csproj
+++ b/Asn1f2/Asn1f2.csproj
@@ -55,7 +55,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="*.cs" />
+    <Compile Include="*.cs" Exclude="Resource1.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resource1.Designer.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Duplicated items in ItemGroup causes Microsoft's msbuild to fail.