### PR TITLE
AstRoot structures cleanup

### DIFF
--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -223,7 +223,7 @@ namespace Asn1f2
             */
             var parameterized_ast = CreateAsn1AstFromAntlrTree.CreateAstRoot(asn1Files, encodings.ToArray(),
                     generateEqualFunctions, cmdArgs.GetOptionalArgument("typePrefix", ""), cmdArgs.HasArgument("oss"),
-                    icdAcnHtmlFileName, mappingFunctionsModule, int.Parse(ws));
+                    mappingFunctionsModule, int.Parse(ws));
 
             /*
              *  Removes parameterized types by resolving them. In the example above
@@ -594,18 +594,10 @@ namespace Asn1f2
                     var renamePolicy = getRenamePolicy(cmdArgs, ParameterizedAsn1Ast.EnumRenamePolicy.NoRenamePolicy);
                     var astForBackend = EnsureUniqueEnumNames.DoWork(refTypesWithNoConstraints, renamePolicy);
 
-                    var htmlFileName = Path.Combine(outDir, astForBackend.IcdAcnHtmlFileName);
+                    var htmlFileName = Path.Combine(outDir, icdAcnHtmlFileName);
                     icdAcn.DoWork("icd_acn.stg", astForBackend, acnAst3, htmlFileName);
                     var cssFileName = Path.ChangeExtension(htmlFileName, ".css");
                     icdAcn.emitCss("icd_acn.stg", astForBackend, acnAst3, cssFileName);
-
-                    /*
-                    var noInnerasn1Ast2 = ReplaceInnerTypes.DoWork(asn1Ast, acnAstResolved, true);
-                    var htmlFileName = Path.Combine(outDir, noInnerasn1Ast2.Item1.IcdAcnHtmlFileName);
-                    icdAcn.DoWork("icd_acn.stg", noInnerasn1Ast2.Item1, acnAstResolved, htmlFileName);
-                    var cssFileName = Path.ChangeExtension(htmlFileName, ".css");
-                    icdAcn.emitCss("icd_acn.stg", noInnerasn1Ast2.Item1, acnAstResolved, cssFileName);
-                    */
                 }
 
             }

--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -223,7 +223,7 @@ namespace Asn1f2
             */
             var parameterized_ast = CreateAsn1AstFromAntlrTree.CreateAstRoot(asn1Files, encodings.ToArray(),
                     generateEqualFunctions, cmdArgs.GetOptionalArgument("typePrefix", ""), cmdArgs.HasArgument("oss"),
-                    astXmlFile, icdUperHtmlFileName, icdAcnHtmlFileName, mappingFunctionsModule, int.Parse(ws));
+                    icdUperHtmlFileName, icdAcnHtmlFileName, mappingFunctionsModule, int.Parse(ws));
 
             /*
              *  Removes parameterized types by resolving them. In the example above
@@ -250,7 +250,7 @@ namespace Asn1f2
                 var uniqueEnums = EnsureUniqueEnumNames.DoWork(asn1Ast0, renamePolicy);
                 //XmlAst.DoWork(uniqueEnums);
 
-                genericBackend.DoWork(uniqueEnums, "xml.stg", uniqueEnums.AstXmlAbsFileName);
+                genericBackend.DoWork(uniqueEnums, "xml.stg", astXmlFile);
 
                 return 0;
             }

--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -223,7 +223,7 @@ namespace Asn1f2
             */
             var parameterized_ast = CreateAsn1AstFromAntlrTree.CreateAstRoot(asn1Files, encodings.ToArray(),
                     generateEqualFunctions, cmdArgs.GetOptionalArgument("typePrefix", ""), cmdArgs.HasArgument("oss"),
-                    icdUperHtmlFileName, icdAcnHtmlFileName, mappingFunctionsModule, int.Parse(ws));
+                    icdAcnHtmlFileName, mappingFunctionsModule, int.Parse(ws));
 
             /*
              *  Removes parameterized types by resolving them. In the example above
@@ -585,7 +585,7 @@ namespace Asn1f2
                 if (cmdArgs.HasArgument("icdUper"))
                 {
                     var noInnerasn1Ast2 = ReplaceInnerTypes.DoWork(asn1Ast, acnAstResolved, true);
-                    var htmlFileName = Path.Combine(outDir, noInnerasn1Ast2.Item1.IcdUperHtmlFileName);
+                    var htmlFileName = Path.Combine(outDir, icdUperHtmlFileName);
                     icdUper.DoWork("icd_uper.stg", noInnerasn1Ast2.Item1, acnAst3, htmlFileName);
                 }
                 if (cmdArgs.HasArgument("icdAcn"))

--- a/Ast/Ast.fs
+++ b/Ast/Ast.fs
@@ -21,7 +21,6 @@ type AstRoot = {
     Encodings:list<Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    AstXmlAbsFileName:string
     IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool

--- a/Ast/Ast.fs
+++ b/Ast/Ast.fs
@@ -21,7 +21,6 @@ type AstRoot = {
     Encodings:list<Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option

--- a/Ast/Ast.fs
+++ b/Ast/Ast.fs
@@ -21,7 +21,6 @@ type AstRoot = {
     Encodings:list<Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option
     integerSizeInBytes : int            //currently only the value of 8 bytes (64 bits) is supported

--- a/Ast/CreateAsn1AstFromAntlrTree.fs
+++ b/Ast/CreateAsn1AstFromAntlrTree.fs
@@ -534,7 +534,7 @@ let rootCheckCyclicDeps (astRoot:list<ITree>) =
     let comparer (m1:StringLoc, t1:StringLoc) (m2:StringLoc, t2:StringLoc) = m1.Value = m2.Value && t1.Value=t2.Value
     DoTopologicalSort2 independentNodes dependentNodes comparer excToThrow |> ignore
 
-let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss icdUperHtmlFileName icdAcnHtmlFileName (mappingFunctionsModule:string) integerSizeInBytes =  
+let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss icdAcnHtmlFileName (mappingFunctionsModule:string) integerSizeInBytes =  
     let astRoot = list |> Seq.toList |> List.map (fun (a,_,_) -> a)
     ITree.RegisterFiles(list |> Seq.map (fun (a,b,_) -> (a,b)))
     //rootCheckCyclicDeps astRoot 
@@ -544,7 +544,6 @@ let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1E
         GenerateEqualFunctions = generateEqualFunctions
         TypePrefix = typePrefix
         CheckWithOss = checkWithOss
-        IcdUperHtmlFileName = icdUperHtmlFileName
         IcdAcnHtmlFileName = icdAcnHtmlFileName
         mappingFunctionsModule = if String.IsNullOrWhiteSpace mappingFunctionsModule then None else Some mappingFunctionsModule
         integerSizeInBytes = integerSizeInBytes

--- a/Ast/CreateAsn1AstFromAntlrTree.fs
+++ b/Ast/CreateAsn1AstFromAntlrTree.fs
@@ -534,7 +534,7 @@ let rootCheckCyclicDeps (astRoot:list<ITree>) =
     let comparer (m1:StringLoc, t1:StringLoc) (m2:StringLoc, t2:StringLoc) = m1.Value = m2.Value && t1.Value=t2.Value
     DoTopologicalSort2 independentNodes dependentNodes comparer excToThrow |> ignore
 
-let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss icdAcnHtmlFileName (mappingFunctionsModule:string) integerSizeInBytes =  
+let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss (mappingFunctionsModule:string) integerSizeInBytes =  
     let astRoot = list |> Seq.toList |> List.map (fun (a,_,_) -> a)
     ITree.RegisterFiles(list |> Seq.map (fun (a,b,_) -> (a,b)))
     //rootCheckCyclicDeps astRoot 
@@ -544,7 +544,6 @@ let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1E
         GenerateEqualFunctions = generateEqualFunctions
         TypePrefix = typePrefix
         CheckWithOss = checkWithOss
-        IcdAcnHtmlFileName = icdAcnHtmlFileName
         mappingFunctionsModule = if String.IsNullOrWhiteSpace mappingFunctionsModule then None else Some mappingFunctionsModule
         integerSizeInBytes = integerSizeInBytes
     }

--- a/Ast/CreateAsn1AstFromAntlrTree.fs
+++ b/Ast/CreateAsn1AstFromAntlrTree.fs
@@ -534,7 +534,7 @@ let rootCheckCyclicDeps (astRoot:list<ITree>) =
     let comparer (m1:StringLoc, t1:StringLoc) (m2:StringLoc, t2:StringLoc) = m1.Value = m2.Value && t1.Value=t2.Value
     DoTopologicalSort2 independentNodes dependentNodes comparer excToThrow |> ignore
 
-let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss astXmlFileName icdUperHtmlFileName icdAcnHtmlFileName (mappingFunctionsModule:string) integerSizeInBytes =  
+let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss icdUperHtmlFileName icdAcnHtmlFileName (mappingFunctionsModule:string) integerSizeInBytes =  
     let astRoot = list |> Seq.toList |> List.map (fun (a,_,_) -> a)
     ITree.RegisterFiles(list |> Seq.map (fun (a,b,_) -> (a,b)))
     //rootCheckCyclicDeps astRoot 
@@ -544,7 +544,6 @@ let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1E
         GenerateEqualFunctions = generateEqualFunctions
         TypePrefix = typePrefix
         CheckWithOss = checkWithOss
-        AstXmlAbsFileName = astXmlFileName
         IcdUperHtmlFileName = icdUperHtmlFileName
         IcdAcnHtmlFileName = icdAcnHtmlFileName
         mappingFunctionsModule = if String.IsNullOrWhiteSpace mappingFunctionsModule then None else Some mappingFunctionsModule

--- a/Ast/MapParamAstToNonParamAst.fs
+++ b/Ast/MapParamAstToNonParamAst.fs
@@ -290,7 +290,6 @@ let DoWork (r:ParameterizedAsn1Ast.AstRoot) : Ast.AstRoot =
         Encodings = r.Encodings |> List.map MapAsn1Encoding
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule

--- a/Ast/MapParamAstToNonParamAst.fs
+++ b/Ast/MapParamAstToNonParamAst.fs
@@ -290,7 +290,6 @@ let DoWork (r:ParameterizedAsn1Ast.AstRoot) : Ast.AstRoot =
         Encodings = r.Encodings |> List.map MapAsn1Encoding
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule
         integerSizeInBytes = r.integerSizeInBytes

--- a/Ast/MapParamAstToNonParamAst.fs
+++ b/Ast/MapParamAstToNonParamAst.fs
@@ -290,7 +290,6 @@ let DoWork (r:ParameterizedAsn1Ast.AstRoot) : Ast.AstRoot =
         Encodings = r.Encodings |> List.map MapAsn1Encoding
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        AstXmlAbsFileName = r.AstXmlAbsFileName
         IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss

--- a/Ast/ParameterizedAsn1Ast.fs
+++ b/Ast/ParameterizedAsn1Ast.fs
@@ -22,7 +22,6 @@ type AstRoot = {
     Encodings:list<Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option
     integerSizeInBytes : int            //currently only the value of 8 bytes (64 bits) is supported

--- a/Ast/ParameterizedAsn1Ast.fs
+++ b/Ast/ParameterizedAsn1Ast.fs
@@ -22,7 +22,6 @@ type AstRoot = {
     Encodings:list<Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    AstXmlAbsFileName:string
     IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool

--- a/Ast/ParameterizedAsn1Ast.fs
+++ b/Ast/ParameterizedAsn1Ast.fs
@@ -22,7 +22,6 @@ type AstRoot = {
     Encodings:list<Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option

--- a/BackendAst/BAstConstruction.fs
+++ b/BackendAst/BAstConstruction.fs
@@ -65,7 +65,6 @@ let createAstRoot (s:State) (sr:Ast.AstRoot) (dfiles: Asn1File list)  (*(acn:Acn
         Encodings = sr.Encodings
         GenerateEqualFunctions = sr.GenerateEqualFunctions
         TypePrefix = sr.TypePrefix
-        IcdUperHtmlFileName = sr.IcdUperHtmlFileName
         IcdAcnHtmlFileName = sr.IcdAcnHtmlFileName
         CheckWithOss = sr.CheckWithOss
         mappingFunctionsModule = sr.mappingFunctionsModule

--- a/BackendAst/BAstConstruction.fs
+++ b/BackendAst/BAstConstruction.fs
@@ -65,7 +65,6 @@ let createAstRoot (s:State) (sr:Ast.AstRoot) (dfiles: Asn1File list)  (*(acn:Acn
         Encodings = sr.Encodings
         GenerateEqualFunctions = sr.GenerateEqualFunctions
         TypePrefix = sr.TypePrefix
-        IcdAcnHtmlFileName = sr.IcdAcnHtmlFileName
         CheckWithOss = sr.CheckWithOss
         mappingFunctionsModule = sr.mappingFunctionsModule
         TypeAssignments = s.anonymousTypes |> List.filter (fun x -> x.asn1Name.IsSome)

--- a/BackendAst/BAstConstruction.fs
+++ b/BackendAst/BAstConstruction.fs
@@ -65,7 +65,6 @@ let createAstRoot (s:State) (sr:Ast.AstRoot) (dfiles: Asn1File list)  (*(acn:Acn
         Encodings = sr.Encodings
         GenerateEqualFunctions = sr.GenerateEqualFunctions
         TypePrefix = sr.TypePrefix
-        AstXmlAbsFileName = sr.AstXmlAbsFileName
         IcdUperHtmlFileName = sr.IcdUperHtmlFileName
         IcdAcnHtmlFileName = sr.IcdAcnHtmlFileName
         CheckWithOss = sr.CheckWithOss

--- a/BackendAst/BastAddAcnInsertFields.fs
+++ b/BackendAst/BastAddAcnInsertFields.fs
@@ -106,7 +106,6 @@ let doWork (r:BAst.AstRoot) (acn:AcnTypes.AcnAst) : AstRoot=
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule
         valsMap  = r.valsMap

--- a/BackendAst/BastAddAcnInsertFields.fs
+++ b/BackendAst/BastAddAcnInsertFields.fs
@@ -106,7 +106,6 @@ let doWork (r:BAst.AstRoot) (acn:AcnTypes.AcnAst) : AstRoot=
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule

--- a/BackendAst/BastAddAcnInsertFields.fs
+++ b/BackendAst/BastAddAcnInsertFields.fs
@@ -106,7 +106,6 @@ let doWork (r:BAst.AstRoot) (acn:AcnTypes.AcnAst) : AstRoot=
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        AstXmlAbsFileName = r.AstXmlAbsFileName
         IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss

--- a/BackendAst/CAst.fs
+++ b/BackendAst/CAst.fs
@@ -603,7 +603,6 @@ type AstRoot = {
     Encodings:list<Ast.Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option

--- a/BackendAst/CAst.fs
+++ b/BackendAst/CAst.fs
@@ -603,7 +603,6 @@ type AstRoot = {
     Encodings:list<Ast.Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option
     valsMap : Map<ReferenceToValue, Asn1GenericValue>

--- a/BackendAst/CAst.fs
+++ b/BackendAst/CAst.fs
@@ -603,7 +603,6 @@ type AstRoot = {
     Encodings:list<Ast.Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    AstXmlAbsFileName:string
     IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool

--- a/BackendAst/CAstConstruction.fs
+++ b/BackendAst/CAstConstruction.fs
@@ -211,7 +211,6 @@ let mapBAstToCast (r:BAst.AstRoot) (acn:AcnTypes.AcnAst) : AstRoot=
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        AstXmlAbsFileName = r.AstXmlAbsFileName
         IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss

--- a/BackendAst/CAstConstruction.fs
+++ b/BackendAst/CAstConstruction.fs
@@ -211,7 +211,6 @@ let mapBAstToCast (r:BAst.AstRoot) (acn:AcnTypes.AcnAst) : AstRoot=
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule
         valsMap  = r.valsMap

--- a/BackendAst/CAstConstruction.fs
+++ b/BackendAst/CAstConstruction.fs
@@ -211,7 +211,6 @@ let mapBAstToCast (r:BAst.AstRoot) (acn:AcnTypes.AcnAst) : AstRoot=
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule

--- a/BackendAst/Constraints.fs
+++ b/BackendAst/Constraints.fs
@@ -405,7 +405,6 @@ type AstRootTemplate<'ASN1TYPE> = {
     Encodings:list<Ast.Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    AstXmlAbsFileName:string
     IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool

--- a/BackendAst/Constraints.fs
+++ b/BackendAst/Constraints.fs
@@ -405,7 +405,6 @@ type AstRootTemplate<'ASN1TYPE> = {
     Encodings:list<Ast.Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option
     valsMap : Map<ReferenceToValue, Asn1GenericValue>

--- a/BackendAst/Constraints.fs
+++ b/BackendAst/Constraints.fs
@@ -405,7 +405,6 @@ type AstRootTemplate<'ASN1TYPE> = {
     Encodings:list<Ast.Asn1Encoding>
     GenerateEqualFunctions:bool
     TypePrefix:string
-    IcdUperHtmlFileName:string
     IcdAcnHtmlFileName:string
     CheckWithOss:bool
     mappingFunctionsModule : string option

--- a/BackendAst/DAst.fs
+++ b/BackendAst/DAst.fs
@@ -905,7 +905,6 @@ type AstRoot = {
     Encodings               : Ast.Asn1Encoding list
     GenerateEqualFunctions  : bool
     TypePrefix              : string
-    AstXmlAbsFileName       : string
     IcdUperHtmlFileName     : string
     IcdAcnHtmlFileName      : string
     CheckWithOss            : bool

--- a/BackendAst/DAst.fs
+++ b/BackendAst/DAst.fs
@@ -905,7 +905,6 @@ type AstRoot = {
     Encodings               : Ast.Asn1Encoding list
     GenerateEqualFunctions  : bool
     TypePrefix              : string
-    IcdAcnHtmlFileName      : string
     CheckWithOss            : bool
     mappingFunctionsModule  : string option
     valsMap                 : Map<ReferenceToValue, Asn1GenericValue>

--- a/BackendAst/DAst.fs
+++ b/BackendAst/DAst.fs
@@ -905,7 +905,6 @@ type AstRoot = {
     Encodings               : Ast.Asn1Encoding list
     GenerateEqualFunctions  : bool
     TypePrefix              : string
-    IcdUperHtmlFileName     : string
     IcdAcnHtmlFileName      : string
     CheckWithOss            : bool
     mappingFunctionsModule  : string option

--- a/BackendAst/DAstConstruction.fs
+++ b/BackendAst/DAstConstruction.fs
@@ -664,7 +664,6 @@ let DoWork (r:CAst.AstRoot) (l:ProgrammingLanguage) =
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule
         valsMap  = r.valsMap

--- a/BackendAst/DAstConstruction.fs
+++ b/BackendAst/DAstConstruction.fs
@@ -664,7 +664,6 @@ let DoWork (r:CAst.AstRoot) (l:ProgrammingLanguage) =
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss
         mappingFunctionsModule = r.mappingFunctionsModule

--- a/BackendAst/DAstConstruction.fs
+++ b/BackendAst/DAstConstruction.fs
@@ -664,7 +664,6 @@ let DoWork (r:CAst.AstRoot) (l:ProgrammingLanguage) =
         Encodings = r.Encodings
         GenerateEqualFunctions = r.GenerateEqualFunctions
         TypePrefix = r.TypePrefix
-        AstXmlAbsFileName = r.AstXmlAbsFileName
         IcdUperHtmlFileName = r.IcdUperHtmlFileName
         IcdAcnHtmlFileName = r.IcdAcnHtmlFileName
         CheckWithOss = r.CheckWithOss


### PR DESCRIPTION
AstRoot did contain some paths to output files, which seems strange for structure representing parsed models.

Also: that data was assigned in Program.cs, copied couple of times and later used in... Program.cs. This refactoring simplifies the code.

It is also first of couple of refactorings I'm going to submit to provide abstraction layer between "IO operations" and "code generation". It's a work towards "daemonizing" asn1scc.