### PR TITLE
[V4] GCC-Style Error format 

### DIFF
--- a/Antlr/Antlr.csproj
+++ b/Antlr/Antlr.csproj
@@ -57,6 +57,7 @@
     <Compile Include="asn1Lexer.cs" />
     <Compile Include="asn1Parser.cs" />
     <Compile Include="Comments.cs" />
+    <Compile Include="ErrorFormatter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Antlr/ErrorFormatter.cs
+++ b/Antlr/ErrorFormatter.cs
@@ -1,0 +1,23 @@
+﻿using Antlr.Runtime;
+
+namespace Antlr
+{
+    public static class ErrorFormatter
+    {
+        private static string FormatErrorHeader(string path, int line, int column)
+        {
+            var arr = new object[] { System.IO.Path.GetFileName(path), ":", line, ":", column, ": error:" };
+            return string.Concat(arr);
+        }
+
+        public static string GetErrorHeader(string path, RecognitionException e)
+        {
+            return FormatErrorHeader(path, e.Line, e.CharPositionInLine);
+        }
+
+        public static string FormatError(string path, int line, int column, string message)
+        {
+            return FormatErrorHeader(path, line, column) + " " + message;
+        }
+    }
+}

--- a/Antlr/acn.g
+++ b/Antlr/acn.g
@@ -52,8 +52,7 @@ public override void EmitErrorMessage(string msg)
 }
 public override string GetErrorHeader(RecognitionException e)
 {
-    object[] objArray1 = new object[] { "File ", System.IO.Path.GetFileName(input.SourceName), ", ", "line ", e.Line, ":", e.CharPositionInLine };
-    return string.Concat(objArray1);
+    return ErrorFormatter.GetErrorHeader(input.SourceName, e);
 }
 }
 
@@ -76,12 +75,11 @@ public override IToken NextToken() {
 
 public override void EmitErrorMessage(string msg)
 {
-    throw new  Antlr.Asn1.asn1Parser.SyntaxErrorException(msg);
+    throw new Antlr.Asn1.asn1Parser.SyntaxErrorException(msg);
 }
 public override string GetErrorHeader(RecognitionException e)
 {
-    object[] objArray1 = new object[] { "File ", System.IO.Path.GetFileName(input.SourceName), ", ", "line ", e.Line, ":", e.CharPositionInLine };
-    return string.Concat(objArray1);
+    return ErrorFormatter.GetErrorHeader(input.SourceName, e);
 }
 
 }

--- a/Antlr/asn1.g
+++ b/Antlr/asn1.g
@@ -131,8 +131,7 @@ public override void EmitErrorMessage(string msg)
 }
 public override string GetErrorHeader(RecognitionException e)
 {
-    object[] objArray1 = new object[] { "File ", System.IO.Path.GetFileName(input.SourceName), ", ", "line ", e.Line, ":", e.CharPositionInLine };
-    return string.Concat(objArray1);
+    return ErrorFormatter.GetErrorHeader(input.SourceName, e);
 }
 }
 
@@ -160,13 +159,11 @@ public override void ReportError(RecognitionException e) {
 
 public override void EmitErrorMessage(string msg)
 {
-//    throw new Semantix.Utils.SyntaxErrorException(msg);
     throw new asn1Parser.SyntaxErrorException(msg);
 }
 public override string GetErrorHeader(RecognitionException e)
 {
-    object[] objArray1 = new object[] { "File ", System.IO.Path.GetFileName(input.SourceName), ", ", "line ", e.Line, ":", e.CharPositionInLine };
-    return string.Concat(objArray1);
+    return ErrorFormatter.GetErrorHeader(input.SourceName, e);
 }
 }
 

--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -72,12 +72,16 @@ namespace Asn1f2
             }
             catch (FsUtils.SemanticError ex)
             {
-                if (ex.Data0.Equals(FsUtils.emptyLocation))
-                    Console.Error.WriteLine("error: {0}", ex.Data1);
-                else
-                    Console.Error.WriteLine(ErrorFormatter.FormatError(ex.Data0.srcFilename, ex.Data0.srcLine, ex.Data0.charPos, ex.Data1));
+                Console.Error.WriteLine(FormatError(ex));
                 return 2;
             }
+        }
+
+        public static string FormatError(FsUtils.SemanticError ex)
+        {
+            if (ex.Data0.Equals(FsUtils.emptyLocation))
+                return "error: " + ex.Data1;
+            return ErrorFormatter.FormatError(ex.Data0.srcFilename, ex.Data0.srcLine, ex.Data0.charPos, ex.Data1);
         }
 
         public static CommonTypes.EnumRenamePolicy getRenamePolicy(CmdLineArgs.CmdLineArguments cmdArgs, CommonTypes.EnumRenamePolicy defaultValue)
@@ -102,10 +106,8 @@ namespace Asn1f2
 
         public static int CheckSuccess(IEnumerable<string> args)
         {
-            var aaa = Resource1.asn1crt;
-
-            var asn1InputFiles = args.Where(a => !a.StartsWith("-") && (a.ToLower().EndsWith(".asn1") || a.ToLower().EndsWith(".asn")));
-            var acnInputFiles = args.Where(a => !a.StartsWith("-") && a.ToLower().EndsWith(".acn"));
+            var asn1InputFiles = args.Where(a => !a.StartsWith("-") && (a.ToLower().EndsWith(".asn1") || a.ToLower().EndsWith(".asn"))).ToList();
+            var acnInputFiles = args.Where(a => !a.StartsWith("-") && a.ToLower().EndsWith(".acn")).ToList();
             
             foreach (var f in asn1InputFiles.Concat(acnInputFiles))
                 if (!File.Exists(f))
@@ -662,13 +664,17 @@ namespace Asn1f2
             backendInvocation(stgFileName, outFileName);
         }
 
+        private static string GetVersionString()
+        {
+            return typeof(Program).Assembly.GetName().Version.ToString(3);
+        }
 
         static int Usage()
         {
             var procName = "asn1";
             Console.Error.WriteLine();
             Console.Error.WriteLine("Semantix ASN.1 Compiler");
-            Console.Error.WriteLine("Current Version is: 3.3.{0} ", Svn.Version);
+            Console.Error.WriteLine("Current Version is: {0} ", GetVersionString());
             Console.Error.WriteLine("Usage:");
             Console.Error.WriteLine();
             Console.Error.WriteLine("{0}  <OPTIONS> file1, file2, ..., fileN ", procName);

--- a/Asn1f2/Program.cs
+++ b/Asn1f2/Program.cs
@@ -19,7 +19,7 @@ using Antlr.Runtime.Tree;
 using System.IO;
 using Antlr.Asn1;
 using Antlr.Acn;
-
+using Antlr;
 
 namespace Asn1f2
 {
@@ -73,14 +73,11 @@ namespace Asn1f2
             catch (FsUtils.SemanticError ex)
             {
                 if (ex.Data0.Equals(FsUtils.emptyLocation))
-                    // do not display empty file/zero line for "emptyLocation"
-                    Console.Error.WriteLine("{0}", ex.Data1);
+                    Console.Error.WriteLine("error: {0}", ex.Data1);
                 else
-                    Console.Error.WriteLine("File:{0}, line:{1}, {2}", Path.GetFileName(ex.Data0.srcFilename), ex.Data0.srcLine, ex.Data1);
+                    Console.Error.WriteLine(ErrorFormatter.FormatError(ex.Data0.srcFilename, ex.Data0.srcLine, ex.Data0.charPos, ex.Data1));
                 return 2;
             }
-
-
         }
 
         public static CommonTypes.EnumRenamePolicy getRenamePolicy(CmdLineArgs.CmdLineArguments cmdArgs, CommonTypes.EnumRenamePolicy defaultValue)

--- a/Asn1f4/Program.fs
+++ b/Asn1f4/Program.fs
@@ -4,6 +4,7 @@ open System
 open System.IO
 open CommonTypes
 open System.Resources
+open Antlr
 
 type CliArguments =
     | [<AltCommandLine("-c")>]C_lang 
@@ -237,7 +238,10 @@ let main0 argv =
             Console.Error.WriteLine(ex.Message)
             2
         | SemanticError (loc,msg)            ->
-            Console.Error.WriteLine("File:{0}, line:{1}, {2}", Path.GetFileName(loc.srcFilename), loc.srcLine, msg);
+            if loc.Equals(FsUtils.emptyLocation) then 
+                Console.Error.WriteLine("error: {0}", msg)
+            else
+                Console.Error.WriteLine(ErrorFormatter.FormatError(loc.srcFilename, loc.srcLine, loc.charPos, msg))
             3
         | ex            ->
             Console.Error.WriteLine(ex.Message)

--- a/Asn1f4/Program.fs
+++ b/Asn1f4/Program.fs
@@ -153,6 +153,11 @@ let exportRTL outDir  (l:DAst.ProgrammingLanguage) =
                 writeTextFile (Path.Combine(outDir, "runSpark.sh"))    (rm.GetString("run",null)) 
                 writeTextFile (Path.Combine(outDir, "GPS_project.gpr"))    (rm.GetString("GPS_project",null)) 
 
+let formatError (loc:SrcLoc) (msg:string) =
+    if loc.Equals(FsUtils.emptyLocation)
+        then "error: " + msg
+        else ErrorFormatter.FormatError(loc.srcFilename, loc.srcLine, loc.charPos, msg)
+
 let main0 argv =
     let parser = ArgumentParser.Create<CliArguments>(programName = "Asn1f4.exe")
     try
@@ -238,10 +243,7 @@ let main0 argv =
             Console.Error.WriteLine(ex.Message)
             2
         | SemanticError (loc,msg)            ->
-            if loc.Equals(FsUtils.emptyLocation) then 
-                Console.Error.WriteLine("error: {0}", msg)
-            else
-                Console.Error.WriteLine(ErrorFormatter.FormatError(loc.srcFilename, loc.srcLine, loc.charPos, msg))
+            Console.WriteLine(formatError loc msg)
             3
         | ex            ->
             Console.Error.WriteLine(ex.Message)

--- a/Tests/test-cases/acn/01-INTEGER/001.asn1
+++ b/Tests/test-cases/acn/01-INTEGER/001.asn1
@@ -8,37 +8,36 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCLFC    MyPDU[encoding pos-int, size 6]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 63 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC    MyPDU[encoding pos-int, size 6]          $$$ sample1.acn:4:30: error: The applied ACN encoding does not allow values larger than 63 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
 --TCLS     CONSTANT WSIZE ::=37 MyPDU[encoding pos-int, size WSIZE]
 --TCLS     CONSTANT WSIZE ::=37/1  MyPDU[encoding pos-int, size WSIZE]
---IGN_TCLFC    MyPDU[encoding pos-int, size 36, adjust 2]          $$$ File:sample1.acn, line:4, Applied ACN encoding  allows values in the range [0, 68719476735] while asn1 type requires values in the range [-1, 68719476734]
---IGN_TCLS    MyPDU[encoding pos-int, size 36, adjust 1]          
---TCLFC    MyPDU[encoding pos-int, size 36]         $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 68719476735 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--IGN_TCLFC    MyPDU[encoding pos-int, size 36, adjust 2]          $$$ sample1.acn:4:30: error: Applied ACN encoding  allows values in the range [0, 68719476735] while asn1 type requires values in the range [-1, 68719476734]
+--IGN_TCLS    MyPDU[encoding pos-int, size 36, adjust 1]
+--TCLFC    MyPDU[encoding pos-int, size 36]         $$$ sample1.acn:4:30: error: The applied ACN encoding does not allow values larger than 68719476735 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
 
---TCLFC     MyPDU[encoding ASCII, size 88]       $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
---TCLFC    CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37 - 1 MyPDU[encoding twos-complement, size WSIZE2]      $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 34359738367 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC     MyPDU[encoding ASCII, size 88]       $$$ sample1.acn:4:28: error: The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC    CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37 - 1 MyPDU[encoding twos-complement, size WSIZE2]      $$$ sample1.acn:4:85: error: The applied ACN encoding does not allow values larger than 34359738367 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
 --TCLS     MyPDU[encoding ASCII, size 104]
 --TCLS     MyPDU[encoding BCD, size 44]
 --TCLS     MyPDU[encoding BCD, size 48]
 --TCLS     MyPDU[encoding ASCII, size 96]
 --TCLS     MyPDU[encoding BCD, size null-terminated]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$ File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC     MyPDU[encoding BCD, size 40]       $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
---TCLFC     MyPDU[encoding BCD, size 41]       $$$ File:sample1.acn, line:4, size value should be multiple of 4
---TCLFC     MyPDU[encoding BCD, size -200]     $$$  File sample1.acn, line 4:21 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$ sample1.acn:4:28: error: size value should be multiple of 8
+--TCLFC     MyPDU[encoding BCD, size 40]       $$$ sample1.acn:4:26: error: The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC     MyPDU[encoding BCD, size 41]       $$$ sample1.acn:4:26: error: size value should be multiple of 4
+--TCLFC     MyPDU[encoding BCD, size -200]     $$$  sample1.acn:4:21: error: no viable alternative at input 'size'
 --TCLS     MyPDU[encoding pos-int, size 37]
 --TCLS     MyPDU[]
---TCLFC     CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37+1 MyPDU[encoding twos-complement, size WSIZE2]  $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLS     MyPDU[encoding pos-int, size 64]		
---TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ File:sample1.acn, line:4, Expecting an Integer value or an ACN constant as value for the size property
+--TCLFC     CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37+1 MyPDU[encoding twos-complement, size WSIZE2]  $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLS     MyPDU[encoding pos-int, size 64]
+--TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ sample1.acn:4:30: error: Expecting an Integer value or an ACN constant as value for the size property
 
--- TCLFC     MyPDU[encoding BCD, size 200]       $$$  File:sample1.acn, line:4, Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+-- TCLFC     MyPDU[encoding BCD, size 200]       $$$  sample1.acn:4:34: error: Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]
--- TCLFC     MyPDU[encoding ASCII, size 200]      $$$ File:sample1.acn, line:4, Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+-- TCLFC     MyPDU[encoding ASCII, size 200]      $$$ sample1.acn:4:34: error: Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
 
 
-        
---   TC   Test Case 
+--   TC   Test Case
 --   L  Line test case
 --   F   complex  test case written in separate File
 --   S  Expected to Succeed

--- a/Tests/test-cases/acn/01-INTEGER/002.asn1
+++ b/Tests/test-cases/acn/01-INTEGER/002.asn1
@@ -8,27 +8,27 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 --TCFC     MyPDU[encoding BCD, size 76]     $$$ Asn.1 compiler error is: File:sample1.acn, line:4, Resulting integer encoding can have values up to 9999999999999999999 which is larger than MAXINT (9223372036854775807)
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
--- TCLS     MyPDU[encoding ASCII, size 160]      
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64, adjust 2]          $$$ File sample1.acn, line 4:34 no viable alternative at input 'adjust'
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:28: error: size value should be multiple of 8
+-- TCLS     MyPDU[encoding ASCII, size 160]
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:61: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64, adjust 2]          $$$ sample1.acn:4:34: error: no viable alternative at input 'adjust'
 
 -- TCLS     MyPDU[encoding BCD, size null-terminated]
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]
---TCLFC     CONSTANT WSIZE ::=63 CONSTANT WSIZE2 ::=64 MyPDU[encoding twos-complement, size WSIZE2]  $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     CONSTANT WSIZE ::=63 CONSTANT WSIZE2 ::=64 MyPDU[encoding twos-complement, size WSIZE2]  $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding pos-int, size WSIZE]
 --TCLS     CONSTANT WSIZE ::=128/2 MyPDU[encoding pos-int, size WSIZE]
--- TCLS    MyPDU[encoding pos-int, size 64, adjust 1]          
+-- TCLS    MyPDU[encoding pos-int, size 64, adjust 1]
 --TCLS     MyPDU[encoding pos-int, size 64]
 --TCLS     MyPDU[]
 
 
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC     MyPDU[encoding BCD, size -200]     $$$  File sample1.acn, line 4:21 no viable alternative at input 'size'
--- TCLFC     MyPDU[encoding BCD, size 200]   $$$ File:sample1.acn, line:4, Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
---TCLFC     MyPDU[encoding BCD, size 41]       $$$  File:sample1.acn, line:4, size value should be multiple of 4
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:28: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding BCD, size -200]     $$$  sample1.acn:4:21: error: no viable alternative at input 'size'
+-- TCLFC     MyPDU[encoding BCD, size 200]   $$$ sample1.acn:4:26: error: Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding BCD, size 41]       $$$  sample1.acn:4:26: error: size value should be multiple of 4
 
--- TCLFC     MyPDU[encoding ASCII, size 200]  $$$ File:sample1.acn, line:4, Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
---TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ File:sample1.acn, line:4, Expecting an Integer value or an ACN constant as value for the size property
---TCLFC     MyPDU[encoding BCD, size 40]       $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+-- TCLFC     MyPDU[encoding ASCII, size 200]  $$$ sample1.acn:4:27: error: Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+--TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ sample1.acn:4:30: error: Expecting an Integer value or an ACN constant as value for the size property
+--TCLFC     MyPDU[encoding BCD, size 40]       $$$ sample1.acn:4:26: error: The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807

--- a/Tests/test-cases/acn/01-INTEGER/003.asn1
+++ b/Tests/test-cases/acn/01-INTEGER/003.asn1
@@ -10,10 +10,10 @@ END
 -- TCLS     MyPDU[encoding ASCII, size 200]  
 
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding twos-complement, size WSIZE]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow negative values which are supported by the corresponding ASN.1 type
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:28: error: size value should be multiple of 8
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:61: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64]          $$$ sample1.acn:4:30: error: The applied ACN encoding does not allow negative values which are supported by the corresponding ASN.1 type
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:28: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
 --TCLS     MyPDU[]
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]

--- a/Tests/test-cases/acn/01-INTEGER/004.asn1
+++ b/Tests/test-cases/acn/01-INTEGER/004.asn1
@@ -7,13 +7,13 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 
--- TCLS     MyPDU[encoding ASCII, size 200]  
+-- TCLS     MyPDU[encoding ASCII, size 200]
 
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding twos-complement, size WSIZE]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow negative values which are supported by the corresponding ASN.1 type
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:28: error: size value should be multiple of 8
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:61: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64]          $$$ sample1.acn:4:30: error: The applied ACN encoding does not allow negative values which are supported by the corresponding ASN.1 type
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:28: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
 --TCLS     MyPDU[]
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]

--- a/Tests/test-cases/acn/01-INTEGER/006.asn1
+++ b/Tests/test-cases/acn/01-INTEGER/006.asn1
@@ -7,13 +7,13 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 
--- TCLS     MyPDU[encoding ASCII, size 200]  
+-- TCLS     MyPDU[encoding ASCII, size 200]
 
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding twos-complement, size WSIZE]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow negative values which are supported by the corresponding ASN.1 type
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:28: error: size value should be multiple of 8
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:61: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64]          $$$ sample1.acn:4:30: error: The applied ACN encoding does not allow negative values which are supported by the corresponding ASN.1 type
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:28: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
 --TCLS     MyPDU[]
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]

--- a/Tests/test-cases/acn/02-REAL/001.asn1
+++ b/Tests/test-cases/acn/02-REAL/001.asn1
@@ -6,7 +6,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCLFC     MyPDU[encoding ASCII]    $$$  File:sample1.acn, line:4, Invalid encoding property value. Expecting 'IEEE754-1985-32' or 'IEEE754-1985-64'
+--TCLFC     MyPDU[encoding ASCII]    $$$  sample1.acn:4:16: error: Invalid encoding property value. Expecting 'IEEE754-1985-32' or 'IEEE754-1985-64'
 --TCLS     MyPDU[encoding IEEE754-1985-64, endianness little]
 --TCLS     MyPDU[encoding IEEE754-1985-64, endianness big]
 --TCLS     MyPDU[]
@@ -14,4 +14,4 @@ END
 --  TCLS     MyPDU[encoding IEEE754-1985-32]   /*In this test cases the final comparison failes due to conversion from double to float*/
 
 
---TCLFC     MyPDU[encoding ASCII, size 100]    $$$  File:sample1.acn, line:4, Acn property 'size' cannot be applied here
+--TCLFC     MyPDU[encoding ASCII, size 100]    $$$  sample1.acn:4:23: error: Acn property 'size' cannot be applied here

--- a/Tests/test-cases/acn/03-IA5String/001.asn1
+++ b/Tests/test-cases/acn/03-IA5String/001.asn1
@@ -7,6 +7,6 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 
---TCLFC    MyPDU[size 20]               $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[size 20]               $$$ sample1.acn:4:12: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
 --TCLS     MyPDU[]
 -- TCLS     MyPDU[size null-terminated]

--- a/Tests/test-cases/acn/03-IA5String/002.asn1
+++ b/Tests/test-cases/acn/03-IA5String/002.asn1
@@ -12,4 +12,4 @@ END
 --TCLS     MyPDU[]
 --TCLS     MyPDU[] { a1[], a2[]}
 -- TCLS     MyPDU[] { a1[], a2[size null-terminated]}
---TCLFC    MyPDU[] { a1[], a2[size 20]}               $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[] { a1[], a2[size 20]}               $$$ sample1.acn:4:25: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant

--- a/Tests/test-cases/acn/03-IA5String/003.asn1
+++ b/Tests/test-cases/acn/03-IA5String/003.asn1
@@ -12,5 +12,5 @@ END
 --TCLS     MyPDU[]
 --TCLS     MyPDU[] { a1[], a2[]}
 -- TCLS     MyPDU[] { a1[], a2[size null-terminated]}
---TCLS    MyPDU[] { a1[], a2[size 20]}               
---TCLFC    MyPDU[] { a1[], a2[size 25]}               $$$ File:sample1.acn, line:4, size property value should be set to 20 
+--TCLS    MyPDU[] { a1[], a2[size 20]}
+--TCLFC    MyPDU[] { a1[], a2[size 25]}               $$$ sample1.acn:4:25: error: size property value should be set to 20 

--- a/Tests/test-cases/acn/03-IA5String/006.asn1
+++ b/Tests/test-cases/acn/03-IA5String/006.asn1
@@ -6,7 +6,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 -- ASCII encodings
---TCLFC    MyPDU[encoding ASCII, size null-terminated, termination-pattern '41'H]               $$$ File:sample1.acn, line:4, The termination-pattern defines a character which belongs to the allowed values of the ASN.1 type. Use another value in the termination-pattern or apply different constraints in the ASN.1 type.
+--TCLFC    MyPDU[encoding ASCII, size null-terminated, termination-pattern '41'H]               $$$ sample1.acn:4:45: error: The termination-pattern defines a character which belongs to the allowed values of the ASN.1 type. Use another value in the termination-pattern or apply different constraints in the ASN.1 type.
 --TCLS     MyPDU[encoding ASCII, size null-terminated, termination-pattern '01'H]
 --TCLS     MyPDU[encoding ASCII, size null-terminated, termination-pattern '00000001'B]
 --TCLS     MyPDU[encoding ASCII, size 20]

--- a/Tests/test-cases/acn/04-ENUMERATED/001.asn1
+++ b/Tests/test-cases/acn/04-ENUMERATED/001.asn1
@@ -10,7 +10,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 --TCLS     MyPDU[encode-values, encoding pos-int, size 10] { alpha[50], beta[60] }
---TCLFC     MyPDU[encode-values, encoding twos-complement, size 10] { alpha[50], beta[60] } $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encode-values, encoding twos-complement, size 10] { alpha[50], beta[60] } $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encode-values, encoding BCD, size 12] { alpha[50], beta[60] }
 --  TCLS     MyPDU[encode-values, encoding BCD, size null-terminated] { alpha[50], beta[60] }
 --TCLS     MyPDU[encode-values, encoding ASCII, size 32] { alpha[50], beta[60] }
@@ -18,7 +18,7 @@ END
 --TCLS     MyPDU[] { alpha[50], beta[60] }
 
 --TCLS     MyPDU[encode-values, encoding pos-int, size 10]
---TCLFC     MyPDU[encode-values, encoding twos-complement, size 10]	$$$ Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encode-values, encoding twos-complement, size 10]	$$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encode-values, encoding BCD, size 12]
 --  TCLS     MyPDU[encode-values, encoding BCD, size null-terminated]
 --TCLS     MyPDU[encode-values, encoding ASCII, size 32]
@@ -28,7 +28,7 @@ END
 
 
 --TCLS     MyPDU[encoding pos-int, size 10]
---TCLFC     MyPDU[encoding twos-complement, size 10]		$$$ Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 10]		$$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encoding BCD, size 8]
 --  TCLS     MyPDU[encoding BCD, size null-terminated]
 --TCLS     MyPDU[encoding ASCII, size 16]

--- a/Tests/test-cases/acn/04-ENUMERATED/002.asn1
+++ b/Tests/test-cases/acn/04-ENUMERATED/002.asn1
@@ -14,7 +14,7 @@ END
 -- TCLS     MyPDU[encode-values, encoding ASCII, size null-terminated]
 --TCLS     MyPDU[]
 --TCLS     MyPDU[encoding pos-int, size 10]
---TCLFC     MyPDU[encoding twos-complement, size 10]    $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 10]    $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encoding BCD, size 8]
 -- TCLS     MyPDU[encoding BCD, size null-terminated]
 --TCLS     MyPDU[encoding ASCII, size 16]

--- a/Tests/test-cases/acn/06-OCTET-STRING/001.asn1
+++ b/Tests/test-cases/acn/06-OCTET-STRING/001.asn1
@@ -8,5 +8,5 @@ END
 
 
 --TCLS     MyPDU[]
---TCLFC    MyPDU[size 20]               $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
---TCLFC    MyPDU[size null-terminated]   $$$ File:sample1.acn, line:4, Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII
+--TCLFC    MyPDU[size 20]               $$$ sample1.acn:4:12: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[size null-terminated]   $$$ sample1.acn:4:12: error: Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII

--- a/Tests/test-cases/acn/06-OCTET-STRING/003.asn1
+++ b/Tests/test-cases/acn/06-OCTET-STRING/003.asn1
@@ -8,5 +8,5 @@ END
 
 
 --TCLS     MyPDU[]
---TCLS    MyPDU[size 7]               
---TCLFC    MyPDU[size 20]               $$$ File:sample1.acn, line:4, size property value should be set to 7
+--TCLS    MyPDU[size 7]
+--TCLFC    MyPDU[size 20]               $$$ sample1.acn:4:12: error: size property value should be set to 7

--- a/Tests/test-cases/acn/06-OCTET-STRING/004.asn1
+++ b/Tests/test-cases/acn/06-OCTET-STRING/004.asn1
@@ -11,7 +11,7 @@ END
 
 --TCLS     MyRange[encoding pos-int, size 5] MyPDU[] {a1 MyRange[], a2[size a1] }
 --TCLS     MyRange[encoding pos-int, size 8] MyPDU[] {a11 MyRange[], a2[size a11] }
---TCLFC     MyRange[encoding twos-complement, size 6] MyPDU[] {a11 MyRange[], a2[size a11] }   $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyRange[encoding twos-complement, size 6] MyPDU[] {a11 MyRange[], a2[size a11] }   $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[] {a11 MyRange[], a2[size a11] }
 --TCLS     MyPDU[]
---TCLFC    MyPDU[] {a1 MyRange[], a2[size 20]}              $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[] {a1 MyRange[], a2[size 20]}              $$$ sample1.acn:4:32: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant

--- a/Tests/test-cases/acn/08-BIT-STRING/001.asn1
+++ b/Tests/test-cases/acn/08-BIT-STRING/001.asn1
@@ -7,4 +7,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 --TCLS     MyPDU[]
---TCLFC    MyPDU[size null-terminated]      $$$ File:sample1.acn, line:4, Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII
+--TCLFC    MyPDU[size null-terminated]      $$$ sample1.acn:4:12: error: Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII

--- a/Tests/test-cases/acn/09-CHOICE/002.asn1
+++ b/Tests/test-cases/acn/09-CHOICE/002.asn1
@@ -23,7 +23,6 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 
 END
 
---TCLFC     MyPDU[determinant tt]       $$$ File:sample1.acn, line:4, invalid reference 'tt'
+--TCLFC     MyPDU[determinant tt]       $$$ sample1.acn:4:19: error: invalid reference 'tt'
 --TCLS     MyPDU[]
---TCLFC     MyPDU[determinant ]       $$$ File sample1.acn, line 4:19 no viable alternative at input ']'
-
+--TCLFC     MyPDU[determinant ]       $$$ sample1.acn:4:19: error: no viable alternative at input ']'

--- a/Tests/test-cases/acn/09-CHOICE/004.asn1
+++ b/Tests/test-cases/acn/09-CHOICE/004.asn1
@@ -33,5 +33,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 
 END
 
---TCLFC     MyPDU[] {a[], inserted ChoiceSelector[], b<inserted>[ ]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel]  $$$ File:sample1.acn, line:4, expecting an enumerated field with names matching the choice names
-
+--TCLFC     MyPDU[] {a[], inserted ChoiceSelector[], b<inserted>[ ]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel]  $$$ sample1.acn:4:121: error: expecting an enumerated field with names matching the choice names

--- a/Tests/test-cases/acn/10-SEQEUENCE/002.asn1
+++ b/Tests/test-cases/acn/10-SEQEUENCE/002.asn1
@@ -8,6 +8,6 @@ TEST-CASE  DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 	pdu1 MyPDU ::= {a 1, b NULL, c "42"}
 --TCLS     MyPDU[] {a[], b[], c[]}
---TCLFC    MyPDU[] {a[], b[]}  $$$ File:sample1.asn1, line:6, No ACN specification provided for 'c' component
+--TCLFC    MyPDU[] {a[], b[]}  $$$ sample1.asn1:6:12: error: No ACN specification provided for 'c' component
 	
 END

--- a/Tests/test-cases/acn/10-SEQEUENCE/006.asn1
+++ b/Tests/test-cases/acn/10-SEQEUENCE/006.asn1
@@ -26,4 +26,4 @@ END
 
 
 --TCLS     MyPDU[]  {int1[], bInt2Present BOOLEAN[], int2[encoding pos-int, size 16, present-when bInt2Present], enm[], buf[], gg[]}  
---TCLFC     MyPDU[size 200]  {int1[], bInt2Present BOOLEAN[], int2[encoding pos-int, size auto, present-when bInt2Present], enm[], buf[], gg[]}   $$$ File:sample1.acn, line:4, Acn property 'size' cannot be applied here
+--TCLFC     MyPDU[size 200]  {int1[], bInt2Present BOOLEAN[], int2[encoding pos-int, size auto, present-when bInt2Present], enm[], buf[], gg[]}   $$$ sample1.acn:4:7: error: Acn property 'size' cannot be applied here

--- a/Tests/test-cases/acn/10-SEQEUENCE/008.asn1
+++ b/Tests/test-cases/acn/10-SEQEUENCE/008.asn1
@@ -23,6 +23,4 @@ END
 --TCLS     MyPDU[] {int1[], bBool BOOLEAN[], int2[present-when bBool], enm[], buf[present-when bBool], gg[present-when bBool]}             
 --TCLS     MyPDU[] 
 --TCLS     MyPDU[] {int1[], bBool BOOLEAN[], int2[], enm[], buf[present-when bBool], gg[present-when bBool]}             
---TCLFC     MyPDU[] {int1[], bBool BOOLEAN[], int2[present-when bBool], enm[present-when bBool], buf[present-when bBool], gg[present-when bBool]}   $$$ File:sample1.acn, line:4, 'present-when' attribute can be applied to optional components only
-
-
+--TCLFC     MyPDU[] {int1[], bBool BOOLEAN[], int2[present-when bBool], enm[present-when bBool], buf[present-when bBool], gg[present-when bBool]}   $$$ sample1.acn:4:65: error: 'present-when' attribute can be applied to optional components only

--- a/Tests/test-cases/acn/11-SEQUENCE-OF/001.asn1
+++ b/Tests/test-cases/acn/11-SEQUENCE-OF/001.asn1
@@ -26,7 +26,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 
---TCLFC    MyPDU[size 20]       $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (0 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
---TCLFC     MyPDU[] {dummy[], dummy2[] }   $$$ File:sample1.acn, line:4, dummy Unexpected field name
+--TCLFC    MyPDU[size 20]       $$$ sample1.acn:4:12: error: The size constraints of the ASN.1  allows variable items (0 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC     MyPDU[] {dummy[], dummy2[] }   $$$ sample1.acn:4:10: error: dummy Unexpected field name
 --TCLS     MyPDU[] 
 --TCLS     MyPDU[] {[] }

--- a/Tests/test-cases/acn/12-PARAM/001_00.asn1
+++ b/Tests/test-cases/acn/12-PARAM/001_00.asn1
@@ -33,5 +33,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCFFC     001_00.acn   $$$ File:sample1.asn1, line:18, ASN.1 fields cannot act as encoding determinants. Remove field 'nrCalls' from the ASN.1 grammar and introduce it in the ACN grammar
-
+--TCFFC     001_00.acn   $$$ sample1.asn1:18:8: error: ASN.1 fields cannot act as encoding determinants. Remove field 'nrCalls' from the ASN.1 grammar and introduce it in the ACN grammar

--- a/Tests/test-cases/acn/12-PARAM/001_02.asn1
+++ b/Tests/test-cases/acn/12-PARAM/001_02.asn1
@@ -20,4 +20,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCFFC     001_02.acn  $$$ File:sample1.asn1, line:11, ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar
+--TCFFC     001_02.acn  $$$ sample1.asn1:11:12: error: ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar

--- a/Tests/test-cases/acn/12-PARAM/001_02_1.asn1
+++ b/Tests/test-cases/acn/12-PARAM/001_02_1.asn1
@@ -22,5 +22,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCFFC     001_02_1.acn	$$$ File:sample1.asn1, line:15, ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar
-
+--TCFFC     001_02_1.acn	$$$ sample1.asn1:15:12: error: ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar

--- a/Tests/test-cases/acn/13-ENDIANESS/002.asn1
+++ b/Tests/test-cases/acn/13-ENDIANESS/002.asn1
@@ -18,14 +18,12 @@ END
 --TCLS     MyPDU[encoding pos-int, size 16, endianness little]
 --TCLS     MyPDU[encoding pos-int, size 32, endianness little]
 --TCLS     MyPDU[encoding pos-int, size 64, endianness little]
---TCLFC     MyPDU[encoding twos-complement, size 16]								$$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 32]                             $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 64]                             $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 16, endianness big]             $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 32, endianness big]             $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 64, endianness big]             $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 16, endianness little]          $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 32, endianness little]          $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 64, endianness little]          $$$ Acn property twos-complement cannot be applied to non negative INTEGER types
-
-        
+--TCLFC     MyPDU[encoding twos-complement, size 16]                             $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 32]                             $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 64]                             $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 16, endianness big]             $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 32, endianness big]             $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 64, endianness big]             $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 16, endianness little]          $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 32, endianness little]          $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 64, endianness little]          $$$ error: Acn property twos-complement cannot be applied to non negative INTEGER types

--- a/Tests/test-cases/acn/15-PUS-ParameterPassing/002.asn1
+++ b/Tests/test-cases/acn/15-PUS-ParameterPassing/002.asn1
@@ -11,4 +11,4 @@ MYMOD DEFINITIONS AUTOMATIC TAGS::= BEGIN
     }
 END 
 
---TCFFC     002.acn  $$$ File:sample1.acn, line:10, Duplicate condition found in choice alternatives
+--TCFFC     002.acn  $$$ sample1.acn:10:50: error: Duplicate condition found in choice alternatives

--- a/v4Tests/test-cases/acn/00-ExpectToFail/001.asn1
+++ b/v4Tests/test-cases/acn/00-ExpectToFail/001.asn1
@@ -8,4 +8,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCLFC    MyPDU[encoding pos-int, size 6]          $$$ File:sample1.asn1, line:3, Cyclic dependencies detected : Type assignment 'TEST-CASE.MyPDU' depends on : 'TEST-CASE.MyPDU2' and Type assignment 'TEST-CASE.MyPDU2' depends on : 'TEST-CASE.MyPDU'
+--TCLFC    MyPDU[encoding pos-int, size 6]          $$$ sample1.asn1:3:1: error: Cyclic dependencies detected : Type assignment 'TEST-CASE.MyPDU' depends on : 'TEST-CASE.MyPDU2' and Type assignment 'TEST-CASE.MyPDU2' depends on : 'TEST-CASE.MyPDU'

--- a/v4Tests/test-cases/acn/01-INTEGER/001.asn1
+++ b/v4Tests/test-cases/acn/01-INTEGER/001.asn1
@@ -8,41 +8,39 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCLFC    MyPDU[encoding pos-int, size 6]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 63 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC    MyPDU[encoding pos-int, size 6]          $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 63 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
 --TCLS     CONSTANT WSIZE ::=37 MyPDU[encoding pos-int, size WSIZE]
 --TCLS     CONSTANT WSIZE ::=37/1  MyPDU[encoding pos-int, size WSIZE]
---IGN_TCLFC    MyPDU[encoding pos-int, size 36, adjust 2]          $$$ File:sample1.acn, line:4, Applied ACN encoding  allows values in the range [0, 68719476735] while asn1 type requires values in the range [-1, 68719476734]
+--IGN_TCLFC    MyPDU[encoding pos-int, size 36, adjust 2]          $$$ sample1.acn:4:3: error: Applied ACN encoding  allows values in the range [0, 68719476735] while asn1 type requires values in the range [-1, 68719476734]
 --IGN_TCLS    MyPDU[encoding pos-int, size 36, adjust 1]          
---TCLFC    MyPDU[encoding pos-int, size 36]         $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 68719476735 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC    MyPDU[encoding pos-int, size 36]         $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 68719476735 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
 
---TCLFC     MyPDU[encoding ASCII, size 88]       $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC     MyPDU[encoding ASCII, size 88]       $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
 --TCLS     MyPDU[encoding BCD, size 44]
 --TCLS     MyPDU[encoding BCD, size 48]
 --TCLS     MyPDU[encoding BCD, size null-terminated]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$ File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC     MyPDU[encoding BCD, size 40]       $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
---TCLFC     MyPDU[encoding BCD, size 41]       $$$ File:sample1.acn, line:4, size value should be multiple of 4
---TCLFC     MyPDU[encoding BCD, size -200]     $$$  File sample1.acn, line 4:21 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$ sample1.acn:4:6: error: size value should be multiple of 8
+--TCLFC     MyPDU[encoding BCD, size 40]       $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 68719476736
+--TCLFC     MyPDU[encoding BCD, size 41]       $$$ sample1.acn:4:6: error: size value should be multiple of 4
+--TCLFC     MyPDU[encoding BCD, size -200]     $$$  sample1.acn:4:21: error: no viable alternative at input 'size'
 --TCLS     MyPDU[encoding pos-int, size 37]
 --TCLS     MyPDU[]
---TCLFC     CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37+1 MyPDU[encoding twos-complement, size WSIZE2]  $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLS     MyPDU[encoding pos-int, size 64]		
---TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ File:sample1.acn, line:4, Expecting an Integer value or an ACN constant as value for the size property
+--TCLFC     CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37+1 MyPDU[encoding twos-complement, size WSIZE2]  $$$ sample1.acn:4:51: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLS     MyPDU[encoding pos-int, size 64]
+--TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ sample1.acn:4:6: error: Expecting an Integer value or an ACN constant as value for the size property
 
--- TCLFC     MyPDU[encoding BCD, size 200]       $$$  File:sample1.acn, line:4, Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+-- TCLFC     MyPDU[encoding BCD, size 200]       $$$  sample1.acn:4:6: error: Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]
--- TCLFC     MyPDU[encoding ASCII, size 200]      $$$ File:sample1.acn, line:4, Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+-- TCLFC     MyPDU[encoding ASCII, size 200]      $$$ sample1.acn:4:6: error: Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
 
---TCLFC    CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37 - 1 MyPDU[encoding twos-complement, size WSIZE2]      $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC    CONSTANT WSIZE ::=37 CONSTANT WSIZE2 ::=37 - 1 MyPDU[encoding twos-complement, size WSIZE2]      $$$ sample1.acn:4:53: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 
 --  TCLS     MyPDU[encoding ASCII, size 96]
 --  TCLS     MyPDU[encoding ASCII, size 104]
-
-        
---   TC   Test Case 
+       
+--   TC   Test Case
 --   L  Line test case
 --   F   complex  test case written in separate File
 --   S  Expected to Succeed
 --   FC  Expected to fail by asn1 compiler
 --   FE  Expected to fail by the generated executable
- 

--- a/v4Tests/test-cases/acn/01-INTEGER/002.asn1
+++ b/v4Tests/test-cases/acn/01-INTEGER/002.asn1
@@ -7,14 +7,14 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
     v64 INTEGER ::= 64
 END
 
---TCFC     MyPDU[encoding BCD, size 76]     $$$ Asn.1 compiler error is: File:sample1.acn, line:4, Resulting integer encoding can have values up to 9999999999999999999 which is larger than MAXINT (9223372036854775807)
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
+--TCFC     MyPDU[encoding BCD, size 76]     $$$ Asn.1 compiler error is: sample1.acn:4:6: error: Resulting integer encoding can have values up to 9999999999999999999 which is larger than MAXINT (9223372036854775807)
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:6: error: size value should be multiple of 8
 -- TCLS     MyPDU[encoding ASCII, size 160]      
---TCLFC    MyPDU[encoding pos-int, size 64, adjust 2]          $$$ File sample1.acn, line 4:34 no viable alternative at input 'adjust'
+--TCLFC    MyPDU[encoding pos-int, size 64, adjust 2]          $$$ sample1.acn:4:34: error: no viable alternative at input 'adjust'
 
 -- TCLS     MyPDU[encoding BCD, size null-terminated]
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]
---TCLFC     CONSTANT WSIZE ::=63 CONSTANT WSIZE2 ::=64 MyPDU[encoding twos-complement, size WSIZE2]  $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     CONSTANT WSIZE ::=63 CONSTANT WSIZE2 ::=64 MyPDU[encoding twos-complement, size WSIZE2]  $$$ sample1.acn:4:49: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding pos-int, size WSIZE]
 --TCLS     CONSTANT WSIZE ::=128/2 MyPDU[encoding pos-int, size WSIZE]
 -- TCLS    MyPDU[encoding pos-int, size 64, adjust 1]          
@@ -22,15 +22,15 @@ END
 --TCLS     MyPDU[]
 
 
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 18446744073709551615
---TCLFC     MyPDU[encoding BCD, size -200]     $$$  File sample1.acn, line 4:21 no viable alternative at input 'size'
--- TCLFC     MyPDU[encoding BCD, size 200]   $$$ File:sample1.acn, line:4, Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
---TCLFC     MyPDU[encoding BCD, size 41]       $$$  File:sample1.acn, line:4, size value should be multiple of 4
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 18446744073709551615
+--TCLFC     MyPDU[encoding BCD, size -200]     $$$  sample1.acn:4:21: error: no viable alternative at input 'size'
+-- TCLFC     MyPDU[encoding BCD, size 200]   $$$ sample1.acn:4:6: error: Resulting integer encoding can have values up to 99999999999999999999999999999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding BCD, size 41]       $$$  sample1.acn:4:6: error: size value should be multiple of 4
 
--- TCLFC     MyPDU[encoding ASCII, size 200]  $$$ File:sample1.acn, line:4, Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
---TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ File:sample1.acn, line:4, Expecting an Integer value or an ACN constant as value for the size property
---TCLFC     MyPDU[encoding BCD, size 40]       $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 18446744073709551615
+-- TCLFC     MyPDU[encoding ASCII, size 200]  $$$ sample1.acn:4:6: error: Resulting integer encoding can have values up to 999999999999999999999999 which is larger than MAXINT (9223372036854775807)
+--TCLFC    MyPDU[encoding pos-int, size h9hd]       $$$ sample1.acn:4:6: error: Expecting an Integer value or an ACN constant as value for the size property
+--TCLFC     MyPDU[encoding BCD, size 40]       $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 9999999999 to be encoded, while the corresponding ASN.1 type allows values up to 18446744073709551615
 
 
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:29: error: Acn property twos-complement cannot be applied to non negative INTEGER types

--- a/v4Tests/test-cases/acn/01-INTEGER/003.asn1
+++ b/v4Tests/test-cases/acn/01-INTEGER/003.asn1
@@ -10,10 +10,10 @@ END
 -- TCLS     MyPDU[encoding ASCII, size 200]  
 
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding twos-complement, size WSIZE]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values smaller than 0 to be encoded, while the corresponding ASN.1 type allows values up to -9223372036854775808
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:6: error: size value should be multiple of 8
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:29: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64]          $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values smaller than 0 to be encoded, while the corresponding ASN.1 type allows values up to -9223372036854775808
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
 --TCLS     MyPDU[]
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]

--- a/v4Tests/test-cases/acn/01-INTEGER/004.asn1
+++ b/v4Tests/test-cases/acn/01-INTEGER/004.asn1
@@ -10,10 +10,10 @@ END
 -- TCLS     MyPDU[encoding ASCII, size 200]  
 
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding twos-complement, size WSIZE]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values smaller than 0 to be encoded, while the corresponding ASN.1 type allows values up to -9223372036854775808
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:6: error: size value should be multiple of 8
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:29: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64]          $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values smaller than 0 to be encoded, while the corresponding ASN.1 type allows values up to -9223372036854775808
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
 --TCLS     MyPDU[]
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]

--- a/v4Tests/test-cases/acn/01-INTEGER/006.asn1
+++ b/v4Tests/test-cases/acn/01-INTEGER/006.asn1
@@ -10,10 +10,10 @@ END
 -- TCLS     MyPDU[encoding ASCII, size 200]  
 
 --TCLS     CONSTANT WSIZE ::=64 MyPDU[encoding twos-complement, size WSIZE]
---TCLFC     MyPDU[encoding ASCII, size 95]       $$$  File:sample1.acn, line:4, size value should be multiple of 8
---TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
---TCLFC    MyPDU[encoding pos-int, size 64]          $$$ File:sample1.acn, line:4, The applied ACN encoding does not allow values smaller than 0 to be encoded, while the corresponding ASN.1 type allows values up to -9223372036854775808
---TCLFC     MyPDU[encoding ASCII, size 152]       $$$  File:sample1.acn, line:4, The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC     MyPDU[encoding ASCII, size 95]       $$$  sample1.acn:4:6: error: size value should be multiple of 8
+--TCLFC    CONSTANT WSIZE ::=64-1 MyPDU[encoding twos-complement, size WSIZE]      $$$  sample1.acn:4:29: error: The applied ACN encoding does not allow values larger than 4611686018427387903 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
+--TCLFC    MyPDU[encoding pos-int, size 64]          $$$ sample1.acn:4:6: error: The applied ACN encoding does not allow values smaller than 0 to be encoded, while the corresponding ASN.1 type allows values up to -9223372036854775808
+--TCLFC     MyPDU[encoding ASCII, size 152]       $$$  sample1.acn:4:6: error: The applied ACN encoding does not allow values larger than 999999999999999999 to be encoded, while the corresponding ASN.1 type allows values up to 9223372036854775807
 --TCLS     MyPDU[]
---TCLFC     MyPDU[encoding ASCII, size -200]     $$$  File sample1.acn, line 4:23 no viable alternative at input 'size'
+--TCLFC     MyPDU[encoding ASCII, size -200]     $$$  sample1.acn:4:23: error: no viable alternative at input 'size'
 -- TCLS     MyPDU[encoding ASCII, size null-terminated]

--- a/v4Tests/test-cases/acn/02-REAL/001.asn1
+++ b/v4Tests/test-cases/acn/02-REAL/001.asn1
@@ -6,7 +6,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCLFC     MyPDU[encoding ASCII]    $$$  File:sample1.acn, line:4, Invalid encoding property value. Expecting 'IEEE754-1985-32' or 'IEEE754-1985-64'
+--TCLFC     MyPDU[encoding ASCII]    $$$  sample1.acn:4:6: error: Invalid encoding property value. Expecting 'IEEE754-1985-32' or 'IEEE754-1985-64'
 --TCLS     MyPDU[encoding IEEE754-1985-64, endianness little]
 --TCLS     MyPDU[encoding IEEE754-1985-64, endianness big]
 --TCLS     MyPDU[]
@@ -14,4 +14,4 @@ END
 --  TCLS     MyPDU[encoding IEEE754-1985-32]   /*In this test cases the final comparison failes due to conversion from double to float*/
 
 
---TCLFC     MyPDU[encoding ASCII, size 100]    $$$  File:sample1.acn, line:4, Acn property 'size' cannot be applied to REAL types
+--TCLFC     MyPDU[encoding ASCII, size 100]    $$$  sample1.acn:4:6: error: Acn property 'size' cannot be applied to REAL types

--- a/v4Tests/test-cases/acn/02-REAL/002.asn1
+++ b/v4Tests/test-cases/acn/02-REAL/002.asn1
@@ -12,5 +12,3 @@ END
 --TCLS     MyPDU[]
 --TCLS     MyPDU[encoding IEEE754-1985-64]
 --  TCLS     MyPDU[encoding IEEE754-1985-32]   /*In this test cases the final comparison failes due to conversion from double to float*/
-
-

--- a/v4Tests/test-cases/acn/03-IA5String/001.asn1
+++ b/v4Tests/test-cases/acn/03-IA5String/001.asn1
@@ -7,6 +7,6 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 
---TCLFC    MyPDU[size 20]               $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[size 20]               $$$ sample1.acn:4:6: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
 --TCLS     MyPDU[]
 -- TCLS     MyPDU[size null-terminated]

--- a/v4Tests/test-cases/acn/03-IA5String/002.asn1
+++ b/v4Tests/test-cases/acn/03-IA5String/002.asn1
@@ -12,4 +12,4 @@ END
 --TCLS     MyPDU[]
 --TCLS     MyPDU[] { a1[], a2[]}
 -- TCLS     MyPDU[] { a1[], a2[size null-terminated]}
---TCLFC    MyPDU[] { a1[], a2[size 20]}               $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[] { a1[], a2[size 20]}               $$$ sample1.acn:4:19: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant

--- a/v4Tests/test-cases/acn/03-IA5String/003.asn1
+++ b/v4Tests/test-cases/acn/03-IA5String/003.asn1
@@ -13,4 +13,4 @@ END
 --TCLS     MyPDU[] { a1[], a2[]}
 -- TCLS     MyPDU[] { a1[], a2[size null-terminated]}
 --TCLS    MyPDU[] { a1[], a2[size 20]}               
---TCLFC    MyPDU[] { a1[], a2[size 25]}               $$$ File:sample1.acn, line:4, The size property must either be ommited or have the fixed value 20
+--TCLFC    MyPDU[] { a1[], a2[size 25]}               $$$ sample1.acn:4:19: error: The size property must either be ommited or have the fixed value 20

--- a/v4Tests/test-cases/acn/03-IA5String/006.asn1
+++ b/v4Tests/test-cases/acn/03-IA5String/006.asn1
@@ -6,7 +6,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 -- ASCII encodings
---TCLFC    MyPDU[encoding ASCII, size null-terminated, termination-pattern '41'H]               $$$ File:sample1.acn, line:4, The termination-pattern defines a character which belongs to the allowed values of the ASN.1 type. Use another value in the termination-pattern or apply different constraints in the ASN.1 type.
+--TCLFC    MyPDU[encoding ASCII, size null-terminated, termination-pattern '41'H]               $$$ sample1.acn:4:6: error: The termination-pattern defines a character which belongs to the allowed values of the ASN.1 type. Use another value in the termination-pattern or apply different constraints in the ASN.1 type.
 --TCLS     MyPDU[encoding ASCII, size null-terminated, termination-pattern '01'H]
 --TCLS     MyPDU[encoding ASCII, size null-terminated, termination-pattern '00000001'B]
 --TCLS     MyPDU[encoding ASCII, size 20]

--- a/v4Tests/test-cases/acn/04-ENUMERATED/001.asn1
+++ b/v4Tests/test-cases/acn/04-ENUMERATED/001.asn1
@@ -10,7 +10,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 --TCLS     MyPDU[encode-values, encoding pos-int, size 10] { alpha[50], beta[60] }
---TCLFC     MyPDU[encode-values, encoding twos-complement, size 10] { alpha[50], beta[60] } $$$ File:sample1.asn1, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encode-values, encoding twos-complement, size 10] { alpha[50], beta[60] } $$$ sample1.asn1:4:11: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encode-values, encoding BCD, size 12] { alpha[50], beta[60] }
 --  TCLS     MyPDU[encode-values, encoding BCD, size null-terminated] { alpha[50], beta[60] }
 --TCLS     MyPDU[encode-values, encoding ASCII, size 32] { alpha[50], beta[60] }
@@ -18,7 +18,7 @@ END
 --TCLS     MyPDU[] { alpha[50], beta[60] }
 
 --TCLS     MyPDU[encode-values, encoding pos-int, size 10]
---TCLFC     MyPDU[encode-values, encoding twos-complement, size 10]	$$$ File:sample1.asn1, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encode-values, encoding twos-complement, size 10]	$$$ sample1.asn1:4:11: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encode-values, encoding BCD, size 12]
 --  TCLS     MyPDU[encode-values, encoding BCD, size null-terminated]
 --TCLS     MyPDU[encode-values, encoding ASCII, size 32]
@@ -28,7 +28,7 @@ END
 
 
 --TCLS     MyPDU[encoding pos-int, size 10]
---TCLFC     MyPDU[encoding twos-complement, size 10]		$$$ File:sample1.asn1, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 10]		$$$ sample1.asn1:4:11: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encoding BCD, size 8]
 --  TCLS     MyPDU[encoding BCD, size null-terminated]
 --TCLS     MyPDU[encoding ASCII, size 16]

--- a/v4Tests/test-cases/acn/04-ENUMERATED/002.asn1
+++ b/v4Tests/test-cases/acn/04-ENUMERATED/002.asn1
@@ -14,7 +14,7 @@ END
 -- TCLS     MyPDU[encode-values, encoding ASCII, size null-terminated]
 --TCLS     MyPDU[]
 --TCLS     MyPDU[encoding pos-int, size 10]
---TCLFC     MyPDU[encoding twos-complement, size 10]    $$$ File:sample1.asn1, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 10]    $$$ sample1.asn1:4:11: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[encoding BCD, size 8]
 -- TCLS     MyPDU[encoding BCD, size null-terminated]
 --TCLS     MyPDU[encoding ASCII, size 16]

--- a/v4Tests/test-cases/acn/06-OCTET-STRING/001.asn1
+++ b/v4Tests/test-cases/acn/06-OCTET-STRING/001.asn1
@@ -8,5 +8,5 @@ END
 
 
 --TCLS     MyPDU[]
---TCLFC    MyPDU[size 20]               $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
---TCLFC    MyPDU[size null-terminated]   $$$ File:sample1.acn, line:4, Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII
+--TCLFC    MyPDU[size 20]               $$$ sample1.acn:4:6: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[size null-terminated]   $$$ sample1.acn:4:6: error: Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII

--- a/v4Tests/test-cases/acn/06-OCTET-STRING/003.asn1
+++ b/v4Tests/test-cases/acn/06-OCTET-STRING/003.asn1
@@ -9,4 +9,4 @@ END
 
 --TCLS     MyPDU[]
 --TCLS    MyPDU[size 7]               
---TCLFC    MyPDU[size 20]               $$$ File:sample1.acn, line:4, The size property must either be ommited or have the fixed value 7
+--TCLFC    MyPDU[size 20]               $$$ sample1.acn:4:6: error: The size property must either be ommited or have the fixed value 7

--- a/v4Tests/test-cases/acn/06-OCTET-STRING/004.asn1
+++ b/v4Tests/test-cases/acn/06-OCTET-STRING/004.asn1
@@ -11,7 +11,7 @@ END
 
 --TCLS     MyRange[encoding pos-int, size 5] MyPDU[] {a1 MyRange[], a2[size a1] }
 --TCLS     MyRange[encoding pos-int, size 8] MyPDU[] {a11 MyRange[], a2[size a11] }
---TCLFC     MyRange[encoding twos-complement, size 6] MyPDU[] {a11 MyRange[], a2[size a11] }   $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyRange[encoding twos-complement, size 6] MyPDU[] {a11 MyRange[], a2[size a11] }   $$$ sample1.acn:4:8: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 --TCLS     MyPDU[] {a11 MyRange[], a2[size a11] }
 --TCLS     MyPDU[]
---TCLFC    MyPDU[] {a1 MyRange[], a2[size 20]}              $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC    MyPDU[] {a1 MyRange[], a2[size 20]}              $$$ sample1.acn:4:26: error: The size constraints of the ASN.1  allows variable items (1 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant

--- a/v4Tests/test-cases/acn/08-BIT-STRING/001.asn1
+++ b/v4Tests/test-cases/acn/08-BIT-STRING/001.asn1
@@ -7,4 +7,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 --TCLS     MyPDU[]
---TCLFC    MyPDU[size null-terminated]      $$$ File:sample1.acn, line:4, Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII
+--TCLFC    MyPDU[size null-terminated]      $$$ sample1.acn:4:6: error: Acn proporty 'size null-terminated' is supported only in IA5String and NumericString string types and in Integer types and when encoding is ASCII

--- a/v4Tests/test-cases/acn/09-CHOICE/002.asn1
+++ b/v4Tests/test-cases/acn/09-CHOICE/002.asn1
@@ -23,7 +23,6 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 
 END
 
---TCLFC     MyPDU[determinant tt]       $$$ File:sample1.acn, line:4, Invalid reference 'tt'
+--TCLFC     MyPDU[determinant tt]       $$$ sample1.acn:4:19: error: Invalid reference 'tt'
 --TCLS     MyPDU[]
---TCLFC     MyPDU[determinant ]       $$$ File sample1.acn, line 4:19 no viable alternative at input ']'
-
+--TCLFC     MyPDU[determinant ]       $$$ sample1.acn:4:19: error: no viable alternative at input ']'

--- a/v4Tests/test-cases/acn/09-CHOICE/003.asn1
+++ b/v4Tests/test-cases/acn/09-CHOICE/003.asn1
@@ -36,10 +36,6 @@ END
 --TCLS     MyPDU[]  ChoiceSelector[]  ChoiceType[]
 --TCLS     MyPDU[] {a[], b[]}   ChoiceSelector[]  ChoiceType[]
 
---TCFC     MyPDU[] {a[], b<a>[]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel] $$$ Asn.1 compiler error is: File:sample1.asn1, line:4, ASN.1 fields cannot act as encoding determinants. Remove field 'a' from the ASN.1 grammar and introduce it in the ACN grammar
+--TCFC     MyPDU[] {a[], b<a>[]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel] $$$ sample1.asn1:4:1: error: ASN.1 fields cannot act as encoding determinants. Remove field 'a' from the ASN.1 grammar and introduce it in the ACN grammar
 
 --TCLS     MyPDU[] {a[], inserted ChoiceSelector[], b<inserted>[]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel]
-
-
-
-

--- a/v4Tests/test-cases/acn/09-CHOICE/004.asn1
+++ b/v4Tests/test-cases/acn/09-CHOICE/004.asn1
@@ -33,5 +33,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 
 END
 
---TCLFC     MyPDU[] {a[], inserted ChoiceSelector[], b<inserted>[ ]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel]  $$$ File:sample1.acn, line:4, expecting an enumerated field with names matching the choice names
-
+--TCLFC     MyPDU[] {a[], inserted ChoiceSelector[], b<inserted>[ ]}   ChoiceSelector[]  ChoiceType<ChoiceSelector:sel>[determinant sel]  $$$ sample1.acn:4:89: error: expecting an enumerated field with names matching the choice names

--- a/v4Tests/test-cases/acn/10-SEQEUENCE/002.asn1
+++ b/v4Tests/test-cases/acn/10-SEQEUENCE/002.asn1
@@ -8,6 +8,6 @@ TEST-CASE  DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 	pdu1 MyPDU ::= {a 1, b NULL, c "42"}
 --TCLS     MyPDU[] {a[], b[], c[]}
---TCLFC    MyPDU[] {a[], b[]}  $$$ File:sample1.acn, line:4, No ACN encoding specification was provided for component c
-	
+--TCLFC    MyPDU[] {a[], b[]}  $$$ sample1.acn:4:6: error: No ACN encoding specification was provided for component c
+
 END

--- a/v4Tests/test-cases/acn/10-SEQEUENCE/006.asn1
+++ b/v4Tests/test-cases/acn/10-SEQEUENCE/006.asn1
@@ -26,4 +26,4 @@ END
 
 
 --TCLS     MyPDU[]  {int1[], bInt2Present BOOLEAN[], int2[encoding pos-int, size 16, present-when bInt2Present], enm[], buf[], gg[]}  
---TCLFC     MyPDU[size 200]  {int1[], bInt2Present BOOLEAN[], int2[encoding pos-int, size auto, present-when bInt2Present], enm[], buf[], gg[]}   $$$ File:sample1.acn, line:4, Expecting an Integer value or an ACN constant as value for the size property
+--TCLFC     MyPDU[size 200]  {int1[], bInt2Present BOOLEAN[], int2[encoding pos-int, size auto, present-when bInt2Present], enm[], buf[], gg[]}   $$$ sample1.acn:4:55: error: Expecting an Integer value or an ACN constant as value for the size property

--- a/v4Tests/test-cases/acn/10-SEQEUENCE/008.asn1
+++ b/v4Tests/test-cases/acn/10-SEQEUENCE/008.asn1
@@ -23,6 +23,4 @@ END
 --TCLS     MyPDU[] {int1[], bBool BOOLEAN[], int2[present-when bBool], enm[], buf[present-when bBool], gg[present-when bBool]}             
 --TCLS     MyPDU[] 
 --TCLS     MyPDU[] {int1[], bBool BOOLEAN[], int2[], enm[], buf[present-when bBool], gg[present-when bBool]}             
---TCLFC     MyPDU[] {int1[], bBool BOOLEAN[], int2[present-when bBool], enm[present-when bBool], buf[present-when bBool], gg[present-when bBool]}   $$$ File:sample1.acn, line:4, present-when attribute cannot be applied here since component enm is not optional
-
-
+--TCLFC     MyPDU[] {int1[], bBool BOOLEAN[], int2[present-when bBool], enm[present-when bBool], buf[present-when bBool], gg[present-when bBool]}   $$$ sample1.acn:4:61: error: present-when attribute cannot be applied here since component enm is not optional

--- a/v4Tests/test-cases/acn/11-SEQUENCE-OF/001.asn1
+++ b/v4Tests/test-cases/acn/11-SEQUENCE-OF/001.asn1
@@ -26,7 +26,7 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 END
 
 
---TCLFC    MyPDU[size 20]       $$$ File:sample1.acn, line:4, The size constraints of the ASN.1  allows variable items (0 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
---TCLFC     MyPDU[] {dummy[], dummy2[] }   $$$ File:sample1.acn, line:4, dummy2 Unexpected field name
+--TCLFC    MyPDU[size 20]       $$$ sample1.acn:4:6: error: The size constraints of the ASN.1  allows variable items (0 .. 20). Therefore, you should either remove the size property (in which case the size determinant will be encoded automatically exactly like uPER), or use a an Integer field as size determinant
+--TCLFC     MyPDU[] {dummy[], dummy2[] }   $$$ sample1.acn:4:10: error: dummy2 Unexpected field name
 --TCLS     MyPDU[] 
 --TCLS     MyPDU[] {[] }

--- a/v4Tests/test-cases/acn/12-PARAM/001_00.acn
+++ b/v4Tests/test-cases/acn/12-PARAM/001_00.acn
@@ -23,5 +23,3 @@ TEST-CASE DEFINITIONS ::= BEGIN
     }
     Call[]
 END  
-
-

--- a/v4Tests/test-cases/acn/12-PARAM/001_00.asn1
+++ b/v4Tests/test-cases/acn/12-PARAM/001_00.asn1
@@ -33,5 +33,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCFFC     001_00.acn   $$$ File:sample1.acn, line:11, ASN.1 fields cannot act as encoding determinants. Remove field 'nrCalls' from the ASN.1 grammar and introduce it in the ACN grammar
-
+--TCFFC     001_00.acn   $$$ sample1.acn:11:22: error: ASN.1 fields cannot act as encoding determinants. Remove field 'nrCalls' from the ASN.1 grammar and introduce it in the ACN grammar

--- a/v4Tests/test-cases/acn/12-PARAM/001_02.asn1
+++ b/v4Tests/test-cases/acn/12-PARAM/001_02.asn1
@@ -20,4 +20,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCFFC     001_02.acn  $$$ File:sample1.acn, line:10, ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar
+--TCFFC     001_02.acn  $$$ sample1.acn:10:52: error: ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar

--- a/v4Tests/test-cases/acn/12-PARAM/001_02_1.acn
+++ b/v4Tests/test-cases/acn/12-PARAM/001_02_1.acn
@@ -9,5 +9,3 @@ TEST-CASE DEFINITIONS ::= BEGIN
    HeaderType[]
    Payload[]
 END  
-
-

--- a/v4Tests/test-cases/acn/12-PARAM/001_02_1.asn1
+++ b/v4Tests/test-cases/acn/12-PARAM/001_02_1.asn1
@@ -22,5 +22,4 @@ TEST-CASE DEFINITIONS AUTOMATIC TAGS::= BEGIN
 	
 END
 
---TCFFC     001_02_1.acn	$$$ File:sample1.acn, line:6, ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar
-
+--TCFFC     001_02_1.acn	$$$ sample1.acn:6:52: error: ASN.1 fields cannot act as encoding determinants. Remove field 'secHeaderFlag' from the ASN.1 grammar and introduce it in the ACN grammar

--- a/v4Tests/test-cases/acn/13-ENDIANESS/002.asn1
+++ b/v4Tests/test-cases/acn/13-ENDIANESS/002.asn1
@@ -18,14 +18,14 @@ END
 --TCLS     MyPDU[encoding pos-int, size 16, endianness little]
 --TCLS     MyPDU[encoding pos-int, size 32, endianness little]
 --TCLS     MyPDU[encoding pos-int, size 64, endianness little]
---TCLFC     MyPDU[encoding twos-complement, size 16]							 $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 32]                             $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 64]                             $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 16, endianness big]             $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 32, endianness big]             $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 64, endianness big]             $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 16, endianness little]          $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 32, endianness little]          $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
---TCLFC     MyPDU[encoding twos-complement, size 64, endianness little]          $$$ File:sample1.acn, line:4, Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 16]							 $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 32]                             $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 64]                             $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 16, endianness big]             $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 32, endianness big]             $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 64, endianness big]             $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 16, endianness little]          $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 32, endianness little]          $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
+--TCLFC     MyPDU[encoding twos-complement, size 64, endianness little]          $$$ sample1.acn:4:6: error: Acn property twos-complement cannot be applied to non negative INTEGER types
 
         

--- a/v4Tests/test-cases/acn/15-PUS-ParameterPassing/002.asn1
+++ b/v4Tests/test-cases/acn/15-PUS-ParameterPassing/002.asn1
@@ -11,4 +11,4 @@ MYMOD DEFINITIONS AUTOMATIC TAGS::= BEGIN
     }
 END 
 
---TCFFC     002.acn  $$$ File:sample1.acn, line:10, Duplicate condition found in choice alternatives
+--TCFFC     002.acn  $$$ sample1.acn:10:50: error: Duplicate condition found in choice alternatives


### PR DESCRIPTION
Reapplied change already present in master (V3).

Currently it fails adaTests on CI, but it the same issue as the one currently failing on main V4 branch itself. cTests are passing, so I'm assuming it's not the issue with this PR.