### PR TITLE
[V4] ImportedModules will appear in XML AST even when only values are imported

### DIFF
--- a/FrontEndAst/MapParamAstToNonParamAst.fs
+++ b/FrontEndAst/MapParamAstToNonParamAst.fs
@@ -343,21 +343,13 @@ let MapValueAssignment (r:ParameterizedAsn1Ast.AstRoot) (m:ParameterizedAsn1Ast.
 
 
 let MapModule (r:ParameterizedAsn1Ast.AstRoot) (m:ParameterizedAsn1Ast.Asn1Module) :Asn1Ast.Asn1Module =
-    let DoImportedModule (x:ParameterizedAsn1Ast.ImportedModule) : Asn1Ast.ImportedModule option =
-        let types = x.Types |> List.choose(fun ts -> 
-                                            let tas = getModuleByName r x.Name |> getTasByName ts
-                                            match tas.Parameters with
-                                            | []    -> Some ts
-                                            | _     -> None     //Paramterized Import, so remove it
-                                       )
-        match types with
-        | []    -> None
-        | _     -> Some  { Asn1Ast.ImportedModule.Name = x.Name; Types = types; Values = x.Values}
+    let DoImportedModule (x:ParameterizedAsn1Ast.ImportedModule) : Asn1Ast.ImportedModule =
+        { Asn1Ast.ImportedModule.Name = x.Name; Types = x.Types; Values = x.Values}
     {
         Asn1Ast.Asn1Module.Name = m.Name
         TypeAssignments = m.TypeAssignments |> List.filter(fun x -> x.Parameters.Length = 0) |> List.map (MapTypeAssignment r m)
         ValueAssignments = m.ValueAssignments |> List.map (MapValueAssignment r m)
-        Imports = m.Imports |> List.choose DoImportedModule
+        Imports = m.Imports |> List.map DoImportedModule
         Exports  = match m.Exports with
                    | ParameterizedAsn1Ast.All               -> Asn1Ast.All
                    | ParameterizedAsn1Ast.OnlySome(lst)     -> Asn1Ast.OnlySome(lst)

--- a/FrontEndAst/RemoveParamterizedTypes.fs
+++ b/FrontEndAst/RemoveParamterizedTypes.fs
@@ -263,9 +263,9 @@ let DoModule (r:AstRoot) (m:Asn1Module) :Asn1Module =
                                             | []    -> Some ts
                                             | _     -> None     //Paramterized Import, so remove it
                                        )
-        match types with
-        | []    -> None
-        | _     -> Some  { ImportedModule.Name = x.Name; Types = types; Values = x.Values}
+        match types, x.Values with
+        | [],[]  -> None
+        | _      -> Some  { ImportedModule.Name = x.Name; Types = types; Values = x.Values}
     
     let newTypeAssignments, newImports = m.TypeAssignments |> List.filter(fun x -> x.Parameters.Length = 0) |> foldMap (DoTypeAssignment r m) []
     let newValueAssignments, newImports = m.ValueAssignments |> foldMap (DoValueAssignment r m) newImports


### PR DESCRIPTION
This closes #115

Also - I've removed some code duplication - in `MapParamAstToNonParamAst.fs` imported modules have already been filtered for parametrized types.