### PR TITLE
[V4] Input files abstraction

### DIFF
--- a/Asn1f4/Program.fs
+++ b/Asn1f4/Program.fs
@@ -118,11 +118,17 @@ let checkArguement arg =
     | AdaUses                   -> ()
     | ACND                      -> ()
 
+let createInput (fileName:string) : Input = 
+    {
+        name = fileName
+        contents = File.OpenRead(fileName)
+    }
+
 let constructCommandLineSettings args (parserResults: ParseResults<CliArguments>)=
     let files = parserResults.GetResult <@ Files @>
     {
-        CommandLineSettings.asn1Files = files |> List.filter(fun a -> (a.ToLower().EndsWith(".asn1")) || (a.ToLower().EndsWith(".asn")) )
-        acnFiles  = files |> List.filter(fun a -> (a.ToLower().EndsWith(".acn")) )
+        CommandLineSettings.asn1Files = files |> List.filter(fun a -> (a.ToLower().EndsWith(".asn1")) || (a.ToLower().EndsWith(".asn")) ) |> List.map createInput
+        acnFiles  = files |> List.filter(fun a -> (a.ToLower().EndsWith(".acn")) ) |> List.map createInput
         encodings = 
             args |> 
             List.choose(fun arg ->

--- a/CommonTypes/CommonTypes.fs
+++ b/CommonTypes/CommonTypes.fs
@@ -2,6 +2,7 @@
 open FsUtils
 open System
 open System.Numerics
+open System.IO
 
 let c_keyworkds =  [ "auto"; "break"; "case"; "char"; "const"; "continue"; "default"; "do"; "double"; "else"; "enum"; "extern"; "float"; "for"; "goto"; "if"; "int"; "long"; "register"; "return"; "short"; "signed"; "sizeof"; "static"; "struct"; "switch"; "typedef"; "union"; "unsigned"; "void"; "volatile"; "while"; ]
 let ada_keyworkds =  [ "abort"; "else"; "new"; "return"; "abs"; "elsif"; "not"; "reverse"; "abstract"; "end"; "null"; "accept"; "entry"; "select"; "access"; "exception"; "of"; "separate"; "aliased"; "exit"; "or"; "some"; "all"; "others"; "subtype"; "and"; "for"; "out"; "synchronized"; "array"; "function"; "overriding"; "at"; "tagged"; "generic"; "package"; "task"; "begin"; "goto"; "pragma"; "terminate"; "body"; "private"; "then"; "if"; "procedure"; "type"; "case"; "in"; "protected"; "constant"; "interface"; "until"; "is"; "raise"; "use"; "declare"; "range"; "delay"; "limited"; "record"; "when"; "delta"; "loop"; "rem"; "while"; "digits"; "renames"; "with"; "do"; "mod"; "requeue"; "xor" ]
@@ -58,9 +59,15 @@ type EnumRenamePolicy =
     | AllEnumerants
 
 
+type Input = {
+    name : string
+    contents : Stream
+}
+
+
 type CommandLineSettings = {
-    asn1Files : string list
-    acnFiles  : string list
+    asn1Files : Input list
+    acnFiles  : Input list
     encodings: Asn1Encoding list
     GenerateEqualFunctions : bool
     generateAutomaticTestCases : bool

--- a/FrontEndAst/FrontEntMain.fs
+++ b/FrontEndAst/FrontEntMain.fs
@@ -14,7 +14,7 @@ open Antlr
 //let CreateAstRoot (list:(ITree*string*array<IToken>) seq) (encodings:array<Asn1Encoding>) generateEqualFunctions typePrefix checkWithOss astXmlFileName icdUperHtmlFileName icdAcnHtmlFileName (mappingFunctionsModule:string) integerSizeInBytes =  
 
 
-let antlrParse (lexer: ICharStream -> #ITokenSource ) parser treeParser (fileName: string, files : string seq) = 
+let antlrParse (lexer: ICharStream -> #ITokenSource ) parser treeParser (name: string, inputs : Input seq) = 
 
     let concatenateStreams (streams : Stream seq) =
         let spaceAscii = (byte 32)
@@ -24,20 +24,20 @@ let antlrParse (lexer: ICharStream -> #ITokenSource ) parser treeParser (fileNam
         memStream :> Stream
 
     let inputStream =
-        match Seq.length files > 1 with
-        | true -> files |> Seq.map (fun f -> File.OpenRead(f) :> Stream) |> concatenateStreams
-        | false -> File.OpenRead(files |> Seq.toList |> List.head) :> Stream
+        match Seq.length inputs > 1 with
+        | true -> inputs |> Seq.map (fun i -> i.contents) |> concatenateStreams
+        | false -> inputs |> Seq.head |> (fun i -> i.contents)
     
     let antlrStream = new ANTLRInputStream(inputStream)
-    antlrStream.SourceName <- fileName
+    antlrStream.SourceName <- name
     let tokenStream = new CommonTokenStream(lexer(antlrStream))
     let tokens = tokenStream.GetTokens().Cast<IToken>() |> Seq.toArray
     let tree = treeParser(parser(tokenStream));
-    {ParameterizedAsn1Ast.AntlrParserResult.fileName = fileName; ParameterizedAsn1Ast.AntlrParserResult.rootItem=tree; ParameterizedAsn1Ast.AntlrParserResult.tokens=tokens}
+    {ParameterizedAsn1Ast.AntlrParserResult.fileName = name; ParameterizedAsn1Ast.AntlrParserResult.rootItem=tree; ParameterizedAsn1Ast.AntlrParserResult.tokens=tokens}
 
 let constructAst (args:CommandLineSettings) =
-    let asn1ParseTrees = args.asn1Files |> Seq.groupBy(fun f -> f) |> Seq.map (antlrParse (fun f -> new asn1Lexer(f)) (fun ts -> new asn1Parser(ts))  (fun p -> p.moduleDefinitions().Tree :?> ITree)  ) |> Seq.toList
-    let acnParseTrees = args.acnFiles |> Seq.groupBy(fun f -> f) |> Seq.map (antlrParse (fun f -> new acnLexer(f)) (fun ts -> new acnParser(ts))  (fun p -> p.moduleDefinitions().Tree :?> ITree)  ) |> Seq.toList
+    let asn1ParseTrees = args.asn1Files |> Seq.groupBy(fun f -> f.name) |> Seq.map (antlrParse (fun f -> new asn1Lexer(f)) (fun ts -> new asn1Parser(ts))  (fun p -> p.moduleDefinitions().Tree :?> ITree)  ) |> Seq.toList
+    let acnParseTrees = args.acnFiles |> Seq.groupBy(fun f -> f.name) |> Seq.map (antlrParse (fun f -> new acnLexer(f)) (fun ts -> new acnParser(ts))  (fun p -> p.moduleDefinitions().Tree :?> ITree)  ) |> Seq.toList
 
     (*
         * constructs a parameterized (templatized) ASN.1 AST by antlr trees.


### PR DESCRIPTION
Streams instead of file names in core functions. Service no longer needs to create temporary input files.

Outputs not yet refactored.