### PR TITLE
[V4] Complete file location in error messages

### DIFF
--- a/Antlr/ErrorFormatter.cs
+++ b/Antlr/ErrorFormatter.cs
@@ -6,7 +6,7 @@ namespace Antlr
     {
         private static string FormatErrorHeader(string path, int line, int column)
         {
-            var arr = new object[] { System.IO.Path.GetFileName(path), ":", line, ":", column, ": error:" };
+            var arr = new object[] { path, ":", line, ":", column, ": error:" };
             return string.Concat(arr);
         }
 

--- a/Tests/scripts/runTests.py
+++ b/Tests/scripts/runTests.py
@@ -77,7 +77,7 @@ def RunTestCase(asn1, acn, behavior, expErrMsg):
         "' '" + resolvedir(asn1File) + "' '" + resolvedir(acnFile) +
         "' >tmp.err 2>&1", True)
     ferr = open("tmp.err", 'r')
-    err_msg = ferr.read().replace("\r\n", "").replace("\n", "")
+    err_msg = ferr.read().replace("\r\n", "").replace("\n", "").replace(targetDir + os.sep, "")
     ferr.close()
     if behavior == 0 or behavior == 2:
         if res != 0 or err_msg != "":

--- a/v4Tests/scripts/runTests.py
+++ b/v4Tests/scripts/runTests.py
@@ -77,7 +77,7 @@ def RunTestCase(asn1, acn, behavior, expErrMsg):
         "' '" + resolvedir(asn1File) + "' '" + resolvedir(acnFile) +
         "' >tmp.err"+"_"+language+" 2>&1", True)
     ferr = open("tmp.err"+"_"+language, 'r')
-    err_msg = ferr.read().replace("\r\n", "").replace("\n", "")
+    err_msg = ferr.read().replace("\r\n", "").replace("\n", "").replace(targetDir + os.sep, "")
     ferr.close()
     if behavior == 0 or behavior == 2:
         if res != 0 or err_msg != "":


### PR DESCRIPTION
Path should be reported as it was passed to the generator (simplifies reading error messages).

Marked as WIP as still needs some polishing in tests