### PR TITLE
XER encoding rules for real values

### DIFF
--- a/asn1crt/xer.c
+++ b/asn1crt/xer.c
@@ -43,7 +43,7 @@ char* UInt2String(asn1SccUint v) {
 }
 
 char* Double2String(double v) {
-    if (v == 0)
+    if (fabs(v) < 1e-17)
         return "0";
 
     static char tmp[256];

--- a/asn1crt/xer.c
+++ b/asn1crt/xer.c
@@ -43,14 +43,26 @@ char* UInt2String(asn1SccUint v) {
 }
 
 char* Double2String(double v) {
-    static char tmp[256];
-    char* pos1 = NULL;
-    snprintf(tmp, sizeof(tmp), "%#.24E", v);
+    if (v == 0)
+        return "0";
 
-    pos1 = strchr(tmp,'+');
-    if (pos1!=NULL) {
-        *pos1=0x0;
-        strcat(tmp, ++pos1);
+    static char tmp[256];
+    int exponent = 0;
+
+    while (fabs(v) >= 10) {
+        v /= 10;
+        exponent++;
+    }
+
+    while (fabs(v) < 1) {
+        v *= 10;
+        exponent--;
+    }
+
+    if (fabs(fabs(v) - llabs((asn1SccSint) v)) < 1e-17) {
+        snprintf(tmp, sizeof(tmp), "%.1fE%d", v, exponent);
+    } else {
+        snprintf(tmp, sizeof(tmp), "%.17gE%d", v, exponent);
     }
 
     return tmp;


### PR DESCRIPTION
Attempt to match the rules:

> 9.2.1 The real value zero shall be encoded as "0".
> 9.2.2 For all other values, the following subclauses specify restrictions that apply to "realnumber" (see ITU-T Rec. X.680 | ISO/IEC 8824-1, 11.9).
> 9.2.3 The "realnumber" shall be normalized so that the integer part consists of a single, non-zero digit. The decimal point shall be present and shall be followed by a fractional part containing at least one digit (which may be zero). The fractional part shall not contain any trailing zeros after the first digit.
> 9.2.4 The fractional part shall be followed by an "E" (not an "e") and by an exponent (which may be zero).
> NOTE – Leading zeros in the exponent are already forbidden by ITU-T Rec. X.680 | ISO/IEC 8824-1, 11.9.
> 9.2.5 No "+" sign shall be present either before the integer part or before the exponent.

Lightly tested, should be more conformant than before and removes the undefined behavior of `strcat`.