### PR TITLE
docker image now can be called as executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,37 @@
-FROM debian:stretch
+# syntax = docker/dockerfile:experimental
+FROM debian:stretch as builder
 
-RUN apt-get update
-RUN apt-get install -y mono-devel mono-complete fsharp mono-xbuild python3 \
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    set -ex ;\
+	apt update ;\
+    apt-get install -y mono-devel mono-complete fsharp mono-xbuild python3 \
     gnat-6 gcc g++ make openjdk-8-jre nuget libgit2-dev libssl-dev
+
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    set -ex ;\
+    apt-get install -y git
+
+RUN set -ex ;\
+    cd /tmp ;\
+    git clone https://github.com/ttsiodras/asn1scc.git ;\
+    cd asn1scc/ ;\
+    nuget restore ;\
+    xbuild /p:TargetFrameworkVersion="v4.5" ;\
+    xbuild /p:Configuration=Release /p:TargetFrameworkVersion="v4.5" ;\
+    cd /tmp ;\
+    mkdir asn1install ;\
+    cd asn1install ;\
+    cp ../asn1scc/Asn1f4/bin/Release/*.dll . ;\
+    cp ../asn1scc/Asn1f4/bin/Release/*.exe . ;\
+    mv Asn1f4.exe asn1.exe ;\
+    chmod +x asn1.exe ;\
+    cp ../asn1scc/Asn1f4/bin/Release/*.stg .
+
+#################################################################################################
+#################################################################################################
+FROM alpine:edge
+
+COPY --from=builder /tmp/asn1install /opt/asn1scc
+
+RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,5 @@
-# syntax = docker/dockerfile:experimental
-FROM debian:stretch as builder
+FROM debian:stretch
 
-RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
-    set -ex ;\
-	apt update ;\
-    apt-get install -y mono-devel mono-complete fsharp mono-xbuild python3 \
+RUN apt-get update
+RUN apt-get install -y mono-devel mono-complete fsharp mono-xbuild python3 \
     gnat-6 gcc g++ make openjdk-8-jre nuget libgit2-dev libssl-dev
-
-RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
-    set -ex ;\
-    apt-get install -y git
-
-RUN set -ex ;\
-    cd /tmp ;\
-    git clone https://github.com/ttsiodras/asn1scc.git ;\
-    cd asn1scc/ ;\
-    nuget restore ;\
-    xbuild /p:TargetFrameworkVersion="v4.5" ;\
-    xbuild /p:Configuration=Release /p:TargetFrameworkVersion="v4.5" ;\
-    cd /tmp ;\
-    mkdir asn1install ;\
-    cd asn1install ;\
-    cp ../asn1scc/Asn1f4/bin/Release/*.dll . ;\
-    cp ../asn1scc/Asn1f4/bin/Release/*.exe . ;\
-    mv Asn1f4.exe asn1.exe ;\
-    chmod +x asn1.exe ;\
-    cp ../asn1scc/Asn1f4/bin/Release/*.stg .
-
-#################################################################################################
-#################################################################################################
-FROM alpine:edge
-
-COPY --from=builder /tmp/asn1install /opt/asn1scc
-
-RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,37 @@
+# syntax = docker/dockerfile:experimental
+FROM debian:stretch as builder
+
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    set -ex ;\
+	apt update ;\
+    apt-get install -y mono-devel mono-complete fsharp mono-xbuild python3 \
+    gnat-6 gcc g++ make openjdk-8-jre nuget libgit2-dev libssl-dev
+
+RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+    set -ex ;\
+    apt-get install -y git
+
+RUN set -ex ;\
+    cd /tmp ;\
+    git clone https://github.com/ttsiodras/asn1scc.git ;\
+    cd asn1scc/ ;\
+    nuget restore ;\
+    xbuild /p:TargetFrameworkVersion="v4.5" ;\
+    xbuild /p:Configuration=Release /p:TargetFrameworkVersion="v4.5" ;\
+    cd /tmp ;\
+    mkdir asn1install ;\
+    cd asn1install ;\
+    cp ../asn1scc/Asn1f4/bin/Release/*.dll . ;\
+    cp ../asn1scc/Asn1f4/bin/Release/*.exe . ;\
+    mv Asn1f4.exe asn1.exe ;\
+    chmod +x asn1.exe ;\
+    cp ../asn1scc/Asn1f4/bin/Release/*.stg .
+
+#################################################################################################
+#################################################################################################
+FROM alpine:edge
+
+COPY --from=builder /tmp/asn1install /opt/asn1scc
+
+RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing

--- a/README.md
+++ b/README.md
@@ -89,32 +89,38 @@ to build it you just need to execute...
 
     docker build -t asn1scc .    # Don't forget the dot!
 
-...and your Docker will build an "asn1scc" Docker image, pre-setup
-with all the build-time dependencies to compile ASN1SCC and run its 
-test suite. You can then enter it and proceed with your development:
+...and your Docker will build an "asn1scc" Docker image. This image can be
+used as if the ASN1SCC is installed on the host system. The [asn1-docker.sh](asn1-docker.sh)
+bash script can be used to wrap the `docker run ...` call into a easy to use compiler command.
+For example, let's assume your ASN files are in a folder as `/tmp/myasnfiles/`. You can use 
+this script file like calling `asn1.exe` file as if it is on your host system. The ASN1SCC will
+be executed inside a docker container and the generated files will appear in the folder
+where the script was called. Assuming that the ASN file is named `sample.asn`, here is a sample
+call of the script (`asn1-docker.sh` script is inside `/opt/asn1scc` folder and the docker image
+named `asn1scc` is already built.)
 
-    $ docker run -it -v $(pwd):/root/asn1scc asn1scc
+```bash
+$ pwd
+/tmp/myasnfiles
+$ cat sample.asn 
+MY-MODULE DEFINITIONS AUTOMATIC TAGS ::= BEGIN
 
-    (Your Docker image starts up)
+Message ::= SEQUENCE {
+    msgId INTEGER,
+    myflag INTEGER,
+    value REAL,
+    szDescription OCTET STRING (SIZE(10)),
+    isReady BOOLEAN
+}
 
-    # cd /root/asn1scc 
-    # xbuild /p:TargetFrameworkVersion="v4.5"
-    ...
+END
+$ /opt/asn1scc/asn1-docker.sh -c -uPER sample.asn
+$ ls 
+acn.c  asn1crt.c  asn1crt.h  real.c  sample.asn  sample.c  sample.h
+```
 
-    ASN1SCC is built at this point - and if you want to run the tests:
-
-    # cd Tests
-    # make
-    ...
-
-This same sequence of commands is executed in CircleCI to check for
-regressions; with the added benefit that after building the base Debian
-for the first time, CircleCI is configured to cache the Docker image.
-This means that upon new commits in ASN1SCC, CircleCI will re-use the 
-baseline Debian with all development tools that was made in previous runs,
-and therefore avoid re-installing all the build environment tools every
-time. Only ASN1SCC is rebuilt from scratch every time - and the
-develop-test cycles are therefore as fast as possible.
+As can be seen above, the host does not have the ASN1SCC installation, but only
+the asn1scc docekr image.
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ DOCKER_BUILDKIT=1 docker build -t asn1scc-runtime -f Dockerfile.asn1scc-runtime 
 ...and your Docker will build an "asn1scc-runtime" Docker image. This image can be
 used as if the ASN1SCC is installed on the host system. The [asn1-docker.sh](asn1-docker.sh)
 bash script can be used to wrap the `docker run ...` call into a easy to use compiler command.
-For example, let's assume your ASN files are in a folder as `/tmp/myasnfiles/`. You can use 
+For example, let's assume your ASN.1 files are in a folder as `/tmp/myasnfiles/`. You can use 
 this script file like calling `asn1.exe` file as if it is on your host system. The ASN1SCC will
 be executed inside a docker container and the generated files will appear in the folder
-where the script was called. Assuming that the ASN file is named `sample.asn`, here is a sample
+where the script was called. Assuming that the ASN.1 file is named `sample.asn`, here is a sample
 call of the script (`asn1-docker.sh` script is inside `/opt/asn1scc` folder and the docker image
 named `asn1scc-runtime` is already built.)
 
@@ -122,7 +122,7 @@ acn.c  asn1crt.c  asn1crt.h  real.c  sample.asn  sample.c  sample.h
 ```
 
 As can be seen above, the host does not have the ASN1SCC installation, but only
-the asn1scc docekr image.
+the asn1scc-runtime docker image.
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ commit or merge request, [we instruct CircleCI](.circleci/config.yml) to...
 - [build ASN1SCC](circleci-build.sh) with the new code inside that image
 - then run all the tests and check the coverage results.
 
-Needless to say, the Docker image can be used for development as well;
-to build it you just need to execute...
+In addition, a runtime docker image can be build with the following command
+which can then be used instead of installing ASN1SCC on the host (or any of
+the dependencies or build tools).
+```
+DOCKER_BUILDKIT=1 docker build -t asn1scc-runtime -f Dockerfile.asn1scc-runtime .
+```
 
-    docker build -t asn1scc .    # Don't forget the dot!
-
-...and your Docker will build an "asn1scc" Docker image. This image can be
+...and your Docker will build an "asn1scc-runtime" Docker image. This image can be
 used as if the ASN1SCC is installed on the host system. The [asn1-docker.sh](asn1-docker.sh)
 bash script can be used to wrap the `docker run ...` call into a easy to use compiler command.
 For example, let's assume your ASN files are in a folder as `/tmp/myasnfiles/`. You can use 
@@ -97,7 +99,7 @@ this script file like calling `asn1.exe` file as if it is on your host system. T
 be executed inside a docker container and the generated files will appear in the folder
 where the script was called. Assuming that the ASN file is named `sample.asn`, here is a sample
 call of the script (`asn1-docker.sh` script is inside `/opt/asn1scc` folder and the docker image
-named `asn1scc` is already built.)
+named `asn1scc-runtime` is already built.)
 
 ```bash
 $ pwd

--- a/asn1-docker.sh
+++ b/asn1-docker.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -v $PWD:/tmp/mounted -w /tmp/mounted -u $(id -u):$(id -g) -e PATH="/opt/asn1scc:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" asn1scc:latest mono /opt/asn1scc/asn1.exe "$@"

--- a/asn1-docker.sh
+++ b/asn1-docker.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run --rm -v $PWD:/tmp/mounted -w /tmp/mounted -u $(id -u):$(id -g) -e PATH="/opt/asn1scc:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" asn1scc:latest mono /opt/asn1scc/asn1.exe "$@"
+docker run --rm -v $PWD:/tmp/mounted -w /tmp/mounted -u $(id -u):$(id -g) -e PATH="/opt/asn1scc:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" asn1scc-runtime mono /opt/asn1scc/asn1.exe "$@"


### PR DESCRIPTION
The modifications (only on Dockerfile. there's a shell script to call the build docker image for convenience) allows the use of the build docker image, as if ASN1SCC is installed on the host. This makes sure that the dependencies of the ASN1SCC is self contained in the docker image and does not interfere with or is affected from the host environment and will generate the same on all platforms.