### PR TITLE
asn1crt: add missing prototypes for (De|En)codeOctetString_fragmentation

### DIFF
--- a/asn1crt/asn1crt_encoding.h
+++ b/asn1crt/asn1crt_encoding.h
@@ -65,7 +65,8 @@ flag BitStream_DecodeReal(BitStream* pBitStrm, asn1Real* v);
 
 flag BitStream_EncodeOctetString_no_length(BitStream* pBitStrm, const byte* arr, int nCount);
 flag BitStream_DecodeOctetString_no_length(BitStream* pBitStrm, byte* arr, int nCount);
-
+flag BitStream_EncodeOctetString_fragmentation(BitStream* pBitStrm, const byte* arr, int nCount);
+flag BitStream_DecodeOctetString_fragmentation(BitStream* pBitStrm, byte* arr, int* nCount, asn1SccSint asn1SizeMax);
 flag BitStream_EncodeOctetString(BitStream* pBitStrm, const byte* arr, int nCount, asn1SccSint min, asn1SccSint max);
 flag BitStream_DecodeOctetString(BitStream* pBitStrm, byte* arr, int* nCount, asn1SccSint min, asn1SccSint max);
 


### PR DESCRIPTION
In f3f7fae201f9 ("support for OCTET STRING (CONTAINING Other-Type)"),
BitStream_EncodeOctetString_fragmentation() and
BitStream_DecodeOctetString_fragmentation() were added, but no
prototypes were added.

When compiling the generated ASN.1 encoders and decoders with g++, the
following error is reported:

"""
error: no previous declaration for ‘flag BitStream_EncodeOctetString_fragmentation(i3ds_asn1::BitStream*, const byte*, int)’
[-Werror=missing-declarations]
flag BitStream_EncodeOctetString_fragmentation(BitStream* pBitStrm, const byte* arr, int nCount) {

compilation terminated due to -Wfatal-errors.
"""