### PR TITLE
asn1crt.h: fix for MSVC compiler

### DIFF
--- a/asn1crt/asn1crt.h
+++ b/asn1crt/asn1crt.h
@@ -4,15 +4,17 @@
 #include <stddef.h>
 
 
-// C99 check
-#if __STDC_VERSION__ >= 199901L
+/* C99 check */
+#if __STDC_VERSION__ >= 199901L || _MSC_VER >= 1900
 #  include <stdbool.h>
 #  include <stdint.h>
 #else
 
+#  ifndef _MSC_VER
 typedef unsigned char bool;
-#  define true 1
-#  define false 0
+#    define true 1u
+#    define false 0u
+#  endif /* _MSC_VER */
 
 typedef unsigned char uint8_t;
 


### PR DESCRIPTION
although MSVC does support C99 headers since version 2015, it does not
support all preprocessor definitions