### PR TITLE
Be careful when referencing defines and do not redeclare built-ins (C++)

### DIFF
--- a/asn1crt/asn1crt.h
+++ b/asn1crt/asn1crt.h
@@ -4,8 +4,12 @@
 #include <stddef.h>
 
 
+#ifdef  __cplusplus
+extern "C" {
+#include <cstdint>
+#else
 // C99 check
-#if __STDC_VERSION__ >= 199901L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
 #  include <stdbool.h>
 #  include <stdint.h>
 #else
@@ -23,10 +27,7 @@ typedef long long int64_t;
 typedef unsigned long long uint64_t;
 
 #endif
-
-#ifdef  __cplusplus
-extern "C" {
-#endif
+#endif	/* __cplusplus */
 
 #ifndef NULL
 #define NULL	0


### PR DESCRIPTION
__STDC_VERSION__ is not mandatory for g++ to define, and when compiling
the generated code with -Werror=undef this yields

    error: "__STDC_VERSION__" is not defined, evaluates to 0

C++ has built-in support for bool, so make sure this is only defined
when __cplusplus is not set. Use cstdint for uintXX_t values.