### PR TITLE
ACN ENUM encoding C: when error is detected, do not try to encode uni…

### DIFF
--- a/StgC/acn_c.stg
+++ b/StgC/acn_c.stg
@@ -479,7 +479,9 @@ switch(<p>) {
         ret = FALSE;                            /*COVERAGE_IGNORE*/
         *pErrCode = <sErrCode>;                 /*COVERAGE_IGNORE*/
 }
-<sActualCodecFunc>
+if (ret) {
+	<sActualCodecFunc>
+}
 >>
 
 EnumeratedEncValues_decode(p, td/*:FE_EnumeratedTypeDefinition*/, arrsItem, sActualCodecFunc, sErrCode, sFirstItemName, sIntVal) ::= <<


### PR DESCRIPTION
…nitialized enum value