### PR TITLE
Update README to link to .NET 7.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Compilation
 First, install the Java JRE. This is a compile-time only dependency,
 required to execute ANTLR.
 
-## Install .NET SDK (version 6.0)
+## Install .NET SDK (version 7.0)
 
-Install the [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0) sdk.
+Install the [.NET 7.0](https://dotnet.microsoft.com/download/dotnet/7.0) sdk.
 Add NuGet package source (in case it is missing) by executing:
     
     dotnet nuget add source "https://api.nuget.org/v3/index.json" --name "NuGet"


### PR DESCRIPTION
Hello! Not sure if documentation is outdated to refer to v6.0 or whether I am missing something. I was able to successfully compile asn1scc from source with .NET 7.0 sdk and I noticed there was a [release a while ago](https://github.com/ttsiodras/asn1scc/releases/tag/4.5.0.0) for .NET 7.0 support